### PR TITLE
Support BuildKit 1.4 syntax (heredocs, `--link`)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@ unreleased
 ----------
 
 - Support BuildKit 1.4 syntax of here-documents in `COPY` instructions. (@MisterDA #99)
+- Support BuildKit 1.4 `--link` flag in `ADD` and `COPY` instructions. (@MisterDA #99)
 
 v8.0.0 2022-07-27 Sydney
 ------------------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,8 @@
 unreleased
 ----------
 
+- Support BuildKit 1.4 syntax of here-documents in `COPY` instructions. (@MisterDA #99)
+
 v8.0.0 2022-07-27 Sydney
 ------------------------
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
+unreleased
+----------
+
 v8.0.0 2022-07-27 Sydney
------------------
+------------------------
 
 - Deprecate Ubuntu 21.10 (@tmcgilchrist #104)
 - Various LCU Updates (@mtelvers #103 #98 #95 #93 #91 #89 #83)

--- a/src/dockerfile.ml
+++ b/src/dockerfile.ml
@@ -22,7 +22,7 @@ type shell_or_exec =
   [@@deriving sexp]
 
 type sources_to_dest =
-  [`From of string option] * [`Src of string list] * [`Dst of string] * [`Chown of string option]
+  [`From of string option] * [`Src of string list] * [`Dst of string] * [`Chown of string option] * [`Link of bool option]
   [@@deriving sexp]
 
 type from = {
@@ -140,11 +140,15 @@ let optional name = function
   | None -> []
   | Some value -> [sprintf "%s=%s" name value]
 
+let optional_flag name = function
+  | Some true -> [name]
+  | Some false | None -> []
 
 let string_of_sources_to_dest (t: sources_to_dest) =
-  let `From frm, `Src sl, `Dst d, `Chown chown = t in
+  let `From frm, `Src sl, `Dst d, `Chown chown, `Link link = t in
   String.concat " " (
-      optional "--chown" chown
+      optional_flag "--link" link
+      @ optional "--chown" chown
       @ optional "--from" frm
       @ [json_array_of_list (sl @ [d])])
 
@@ -220,9 +224,9 @@ let expose_ports p : t = [`Expose p]
 
 let env e : t = [`Env e]
 
-let add ?chown ?from ~src ~dst () : t = [`Add (`From from, `Src src, `Dst dst, `Chown chown)]
+let add ?link ?chown ?from ~src ~dst () : t = [`Add (`From from, `Src src, `Dst dst, `Chown chown, `Link link)]
 
-let copy ?chown ?from ~src ~dst () : t = [`Copy (`From from, `Src src, `Dst dst, `Chown chown)]
+let copy ?link ?chown ?from ~src ~dst () : t = [`Copy (`From from, `Src src, `Dst dst, `Chown chown, `Link link)]
 
 let copy_heredoc ?chown ~src ~dst () : t = [`Copy_heredoc (`Chown chown, src, dst)]
 

--- a/src/dockerfile.mli
+++ b/src/dockerfile.mli
@@ -59,7 +59,7 @@ type parser_directive =
 val parser_directive : parser_directive -> t
 (** A parser directive. If used, needs to be the first line of the
    Dockerfile.
-   @see <https://docs.docker.com/engine/reference/builder/#parser-directives>. *)
+   @see <https://docs.docker.com/engine/reference/builder/#parser-directives> *)
 
 val comment : ('a, unit, string, t) format4 -> 'a
 (** Adds a comment to the Dockerfile for documentation purposes *)
@@ -112,16 +112,16 @@ val cmd : ('a, unit, string, t) format4 -> 'a
   you must specify an {!entrypoint} as well.  The string result of formatting
   [arg] will be passed as a [/bin/sh -c] invocation.
 
-  There can only be one [cmd] in a Dockerfile. If you list more than one 
+  There can only be one [cmd] in a Dockerfile. If you list more than one
   then only the last [cmd] will take effect. *)
 
 val cmd_exec : string list -> t
 (** [cmd_exec args] provides defaults for an executing container. These defaults
   can include an executable, or they can omit the executable, in which case
   you must specify an {!entrypoint} as well.  The first argument to the [args]
-  list must be the full path to the executable. 
+  list must be the full path to the executable.
 
-  There can only be one [cmd] in a Dockerfile. If you list more than one 
+  There can only be one [cmd] in a Dockerfile. If you list more than one
   then only the last [cmd] will take effect. *)
 
 val expose_port : int -> t
@@ -148,7 +148,7 @@ val add : ?chown:string -> ?from:string -> src:string list -> dst:string -> unit
   is being built (the context of the build).
 
   Each [src] may contain wildcards and matching will be done using
-  Go's filepath.Match rules. 
+  Go's filepath.Match rules.
 
   All new files and directories are created with a UID and GID of 0.
   In the case where [src] is a remote file URL, the destination will
@@ -160,8 +160,8 @@ val add : ?chown:string -> ?from:string -> src:string list -> dst:string -> unit
   should be updated.
 
   The [?from] parameter allows artefacts to be retrieved from multiple
-  {!commands}. It can either be an integer number (starting with 0 for the
-  first {!from} command, or a named stage (supplied via [?alias] to the
+  stages. It can either be an integer number (starting with 0 for the
+  first {!from} stage, or a named stage (supplied via [?alias] to the
   {!from} command). *)
 
 val copy : ?chown:string -> ?from:string -> src:string list -> dst:string -> unit -> t

--- a/src/dockerfile.mli
+++ b/src/dockerfile.mli
@@ -64,6 +64,24 @@ val parser_directive : parser_directive -> t
 val comment : ('a, unit, string, t) format4 -> 'a
 (** Adds a comment to the Dockerfile for documentation purposes *)
 
+type heredoc
+(** Build here-document values with {!val:heredoc}. *)
+
+val heredoc : ?strip:bool -> ?word:string -> ?delimiter:string -> ('a, unit, string, heredoc) format4 -> 'a
+(** [heredoc ~word here_document] creates a {!type:heredoc} value with
+    [here_document] as content and [word] () as opening delimiter. If
+    [word] is quoted, then [delimiter] (unquoted [word]) needs to be
+    specified. Quoting affects expansion in the here-document.
+    Requires BuildKit 1.4 {{!val:parser_directive}syntax}.
+
+    @param strip Whether to strip leading tab characters. Defaults to false.
+    @param word The opening delimiter, possibly quoted. Defaults to [EOF].
+    @param delimiter The closing delimiter, unquoted. Defaults to the
+      content of [word].
+
+    @see <https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_07_04> POSIX 2.7.4 Here-Document
+    @see <https://github.com/moby/buildkit/blob/master/frontend/dockerfile/docs/syntax.md#here-documents> BuildKit Here-Documents *)
+
 val from : ?alias:string -> ?tag:string -> ?platform:string -> string -> t
 (** The [from] instruction sets the base image for subsequent instructions.
 
@@ -168,6 +186,12 @@ val copy : ?chown:string -> ?from:string -> src:string list -> dst:string -> uni
 (** [copy ?from ~src ~dst ()] copies new files or directories from [src] and
   adds them to the filesystem of the container at the path [dst]. See
   {!add} for more detailed documentation. *)
+
+val copy_heredoc : ?chown:string -> src:(heredoc list) -> dst:string -> unit -> t
+(** [copy_heredoc src dst] creates the file [dst] using the content of
+    the here-documents [src]. Requires BuildKit 1.4 {{!val:parser_directive}syntax}.
+
+    @see <https://github.com/moby/buildkit/blob/master/frontend/dockerfile/docs/syntax.md#here-documents> *)
 
 val user : ('a, unit, string, t) format4 -> 'a
 (** [user fmt] sets the user name or UID to use when running the image

--- a/src/dockerfile.mli
+++ b/src/dockerfile.mli
@@ -156,10 +156,10 @@ val env : (string * string) list -> t
   instructions. This is functionally equivalent to prefixing a shell
   command with [<key>=<value>]. *)
 
-val add : ?chown:string -> ?from:string -> src:string list -> dst:string -> unit -> t
-(** [add ?from ~src ~dst ()] copies new files, directories or remote file URLs
-  from [src] and adds them to the filesystem of the container at the
-  [dst] path.
+val add : ?link:bool -> ?chown:string -> ?from:string -> src:string list -> dst:string -> unit -> t
+(** [add ?link ?chown ?from ~src ~dst ()] copies new files,
+    directories or remote file URLs from [src] and adds them to the
+    filesystem of the container at the [dst] path.
 
   Multiple [src] resource may be specified but if they are files or
   directories then they must be relative to the source directory that
@@ -177,15 +177,38 @@ val add : ?chown:string -> ?from:string -> src:string list -> dst:string -> unit
   determination of whether or not the file has changed and the cache
   should be updated.
 
-  The [?from] parameter allows artefacts to be retrieved from multiple
-  stages. It can either be an integer number (starting with 0 for the
-  first {!from} stage, or a named stage (supplied via [?alias] to the
-  {!from} command). *)
+  @param link Add files with enhanced semantics where your files
+    remain independent on their own layer and don’t get invalidated
+    when commands on previous layers are changed. Requires BuildKit
+    1.4 {{!val:parser_directive}syntax}.
 
-val copy : ?chown:string -> ?from:string -> src:string list -> dst:string -> unit -> t
-(** [copy ?from ~src ~dst ()] copies new files or directories from [src] and
-  adds them to the filesystem of the container at the path [dst]. See
-  {!add} for more detailed documentation. *)
+  @param chown Specify a given username, groupname, or UID/GID
+    combination to request specific ownership of the copied
+    content.
+
+  @param from Allows artefacts to be retrieved from multiple
+    stages. It can either be an integer number (starting with 0 for
+    the first {!from} stage, or a named stage (supplied via [?alias]
+    to the {!from} command). *)
+
+val copy : ?link:bool -> ?chown:string -> ?from:string -> src:string list -> dst:string -> unit -> t
+(** [copy ?link ?chown ?from ~src ~dst ()] copies new files or
+    directories from [src] and adds them to the filesystem of the
+    container at the path [dst]. See {!add} for more detailed
+    documentation.
+
+  @param link Copy files with enhanced semantics where your files
+    remain independent on their own layer and don’t get invalidated
+    when commands on previous layers are changed. Requires BuildKit
+    1.4 {{!val:parser_directive}syntax}.
+
+  @param chown Specify a given username, groupname, or UID/GID
+    combination to request specific ownership of the copied content.
+
+  @param from Allows artefacts to be retrieved from multiple
+    stages. It can either be an integer number (starting with 0 for
+    the first {!from} stage, or a named stage (supplied via [?alias]
+    to the {!from} command). *)
 
 val copy_heredoc : ?chown:string -> src:(heredoc list) -> dst:string -> unit -> t
 (** [copy_heredoc src dst] creates the file [dst] using the content of


### PR DESCRIPTION
I just saw that [BuildKit 1.4 syntax](https://github.com/moby/buildkit/blob/master/frontend/dockerfile/docs/syntax.md#here-documents) has support for here-documents in `RUN` and `COPY` instructions. I've added support for `COPY`, and used it in the small shell-scripts we output.
I've also added a new `link` flag to the `COPY` and `ADD` instructions.
The "breaking change" is that the generated Dockerfile from `gen_opam2_distro` now uses BuildKit syntax.
BuildKit syntax is only supported with Linux containers.