### PR TITLE
Build Cygwin (& OCaml for Windows) in a sep multistage image, then copy

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 unreleased
 ----------
 
+- Refactor to be able to install Cygwin and OCaml for Windows in a
+  separate multistage build image, then copy. Docker Engine 20.10.18
+  for Windows is currently buggy and doesn't allow it.
+  (@MisterDA #114)
 - Support `ARG` Dockerfile instruction (@MisterDA #116 #117)
 - Bump to OCaml 4.08 and remove dependencies on result and rresult (@MisterDA #106)
 - Wrap libraries:

--- a/src-opam/windows.ml
+++ b/src-opam/windows.ml
@@ -177,7 +177,7 @@ module Cygwin = struct
 
   let cygwin ?(cyg = default) fmt =
     ksprintf
-      (run {|%s %s --root %s --site %s --symlink-type=wsl %s|} cygsetup
+      (run {|%s %s --root %s --site %s --symlink-type=native %s|} cygsetup
          (String.concat " " cyg.args)
          cyg.root cyg.site)
       fmt

--- a/src-opam/windows.ml
+++ b/src-opam/windows.ml
@@ -40,6 +40,7 @@ let run_ocaml_env args fmt =
 
 let cleanup t = t @@ run_powershell {|Remove-Item 'C:\TEMP' -Recurse|} |> crunch
 
+(* VC redist is needed to run WinGet. *)
 let install_vc_redist ?(vs_version = "16") () =
   add
     ~src:[ "https://aka.ms/vs/" ^ vs_version ^ "/release/vc_redist.x64.exe" ]


### PR DESCRIPTION
This last commit changes the Windows images to install Cygwin and OCaml for Windows in a separate multistage image. The idea is that the installation never leaves `C:\cygwin64` and doesn't change the environment apart from adding cygwin's `/bin` to the `PATH`, but we're doing that manually anyway, so it should be safe to copy `C:\cygwin64`.
If we ever get some form of BuildKit for Windows, then Winget and Cygwin retrieval and installation will be done in parallel!
I think we gain more readability by closing in behaviours of WinGet and Cygwin installs, separation of concerns from the main image, and overall better understanding of the end image. It's possible that we also may gain better sharing when building the images. Also, we don't have to remove the cache from the build image.

Includes:
- #112 
- #113 