### PR TITLE
Support `STOPSIGNAL` instruction

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 unreleased
 ----------
 
+- Support STOPSIGNAL instruction. (@MisterDA #121, review by @avsm)
 - Support HEALTHCHECK instruction. (@MisterDA #122, review by @avsm)
 - Various LCU Updates, deprecate Windows 10 20H2
   (@mtelvers #115 #109 #107)

--- a/src/dockerfile.ml
+++ b/src/dockerfile.ml
@@ -82,7 +82,8 @@ type line =
   | `Workdir of string
   | `Onbuild of line
   | `Label of (string * string) list
-  | `Healthcheck of healthcheck ]
+  | `Healthcheck of healthcheck
+  | `Stopsignal of string ]
 [@@deriving sexp]
 
 type t = line list [@@deriving sexp]
@@ -219,6 +220,7 @@ let rec string_of_line ~escape (t : line) =
   | `Workdir wd -> cmd "WORKDIR" wd
   | `Onbuild t -> cmd "ONBUILD" (string_of_line ~escape t)
   | `Label ls -> cmd "LABEL" (string_of_label_list ls)
+  | `Stopsignal s -> cmd "STOPSIGNAL" s
   | `Healthcheck (`Cmd (opts, c)) ->
       cmd "HEALTHCHECK" (string_of_healthcheck ~escape opts c)
   | `Healthcheck `None -> "HEALTHCHECK NONE"
@@ -267,6 +269,7 @@ let entrypoint fmt = ksprintf (fun e -> [ `Entrypoint (`Shell e) ]) fmt
 let entrypoint_exec e : t = [ `Entrypoint (`Exec e) ]
 let shell s : t = [ `Shell s ]
 let workdir fmt = ksprintf (fun wd -> [ `Workdir wd ]) fmt
+let stopsignal s = [ `Stopsignal s ]
 
 let healthcheck ?interval ?timeout ?start_period ?retries fmt =
   let opts = { interval; timeout; start_period; retries } in

--- a/src/dockerfile.mli
+++ b/src/dockerfile.mli
@@ -365,6 +365,10 @@ val healthcheck_none : unit -> t
 (** [healthcheck_none] disables any healthcheck inherited from the
   base image. *)
 
+val stopsignal : string -> t
+(** [stopsignal signal] sets the system call signal that will be
+    sent to the container to exit. *)
+
 val crunch : t -> t
 (** [crunch t] will reduce coincident {!run} commands into a single
   one that is chained using the shell [&&] operator. This reduces the


### PR DESCRIPTION
https://docs.docker.com/engine/reference/builder/#stopsignal

Is exposing `stopsignal_int` and `stopsignal_name` better than ``stopsignal [`Int of int | `Name of string]``? It's probably more consistent this way.