### PR TITLE
Remove opam-2.0 def, defaults to opam-2.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 unreleased
 ----------
 
+- Remove opam 2.0 definition, defaults to opam 2.1. (@MisterDA, #123)
 - Support STOPSIGNAL instruction. (@MisterDA #121, review by @avsm)
 - Support HEALTHCHECK instruction. (@MisterDA #122, review by @avsm)
 - Various LCU Updates, deprecate Windows 10 20H2

--- a/src-opam/opam.ml
+++ b/src-opam/opam.ml
@@ -160,7 +160,6 @@ let header ?win10_revision ?arch ?maintainer ?img ?tag d =
   @@ from ?platform ~tag img @@ maintainer @@ shell
 
 type opam_hashes = {
-  opam_2_0_hash : string;
   opam_2_1_hash : string;
   opam_master_hash : string;
 }
@@ -174,23 +173,16 @@ type opam_branch = {
 }
 
 let create_opam_branches opam_hashes =
-  let { opam_2_0_hash; opam_2_1_hash; opam_master_hash } = opam_hashes in
+  let { opam_2_1_hash; opam_master_hash } = opam_hashes in
   ( opam_master_hash,
     [
-      {
-        branch = "2.0";
-        hash = opam_2_0_hash;
-        enable_0install_solver = false;
-        public_name = "opam-2.0";
-        aliases = [ "opam" ];
-        (* Default *)
-      };
       {
         branch = "2.1";
         hash = opam_2_1_hash;
         enable_0install_solver = true;
         public_name = "opam-2.1";
-        aliases = [];
+        aliases = [ "opam" ];
+        (* Default *)
       };
       {
         branch = "master";

--- a/src-opam/opam.mli
+++ b/src-opam/opam.mli
@@ -41,7 +41,6 @@ val install_opam_from_source :
     solver should be accessible in the resulting opam binary. *)
 
 type opam_hashes = {
-  opam_2_0_hash : string;
   opam_2_1_hash : string;
   opam_master_hash : string;
 }


### PR DESCRIPTION
Defaulting to opam-2.1 removes the step of converting the opamroot to the new layout. Should the definition need to be kept, we could switch the fields of `opam_hashes` to `string option` to trigger the build of the corresponding opam version.