### PR TITLE
Add Fedora 37 to Tier 2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,7 @@
 unreleased
 ----------
 
-- Add Fedora 36. (@MisterDA #125)
+- Add Fedora 36 and 37 and deprecate 34 and 35. (@MisterDA #125, #126)
 - Add Ubuntu 22.10. (@MisterDA #124)
 - Support STOPSIGNAL instruction. (@MisterDA #121, review by @avsm)
 - Support HEALTHCHECK instruction. (@MisterDA #122, review by @avsm)

--- a/src-opam/distro.ml
+++ b/src-opam/distro.ml
@@ -234,7 +234,8 @@ type distro =
     | `V33
     | `V34
     | `V35
-    | `V36 ]
+    | `V36
+    | `V37 ]
   | `OracleLinux of [ `V7 | `V8 ]
   | `OpenSUSE of [ `V42_1 | `V42_2 | `V42_3 | `V15_0 | `V15_1 | `V15_2 | `V15_3 ]
   | `Ubuntu of
@@ -297,6 +298,7 @@ type t =
     | `V34
     | `V35
     | `V36
+    | `V37
     | `Latest ]
   | `OracleLinux of [ `V7 | `V8 | `Latest ]
   | `OpenSUSE of
@@ -403,6 +405,7 @@ let distros : t list =
     `Fedora `V34;
     `Fedora `V35;
     `Fedora `V36;
+    `Fedora `V37;
     `Fedora `Latest;
     `OracleLinux `V7;
     `OracleLinux `V8;
@@ -515,7 +518,7 @@ let resolve_alias (d : t) : distro =
   | `Alpine `Latest -> `Alpine `V3_16
   | `CentOS `Latest -> `CentOS `V7
   | `Debian `Stable -> `Debian `V11
-  | `Fedora `Latest -> `Fedora `V36
+  | `Fedora `Latest -> `Fedora `V37
   | `OracleLinux `Latest -> `OracleLinux `V8
   | `OpenSUSE `Latest -> `OpenSUSE `V15_3
   | `Ubuntu `Latest -> `Ubuntu `V22_10
@@ -530,7 +533,7 @@ let resolve_alias (d : t) : distro =
     | `Debian (`V7 | `V8 | `V9 | `V10 | `V11 | `Testing | `Unstable)
     | `Fedora
         ( `V21 | `V22 | `V23 | `V24 | `V25 | `V26 | `V27 | `V28 | `V29 | `V30
-        | `V31 | `V32 | `V33 | `V34 | `V35 | `V36 )
+        | `V31 | `V32 | `V33 | `V34 | `V35 | `V36 | `V37 )
     | `OracleLinux (`V7 | `V8)
     | `OpenSUSE (`V42_1 | `V42_2 | `V42_3 | `V15_0 | `V15_1 | `V15_2 | `V15_3)
     | `Ubuntu
@@ -567,9 +570,9 @@ let distro_status (d : t) : status =
     | `Debian `Unstable -> `Active `Tier3
     | `Fedora
         ( `V21 | `V22 | `V23 | `V24 | `V25 | `V26 | `V27 | `V28 | `V29 | `V30
-        | `V31 | `V32 | `V33 | `V34 ) ->
+        | `V31 | `V32 | `V33 | `V34 | `V35 ) ->
         `Deprecated
-    | `Fedora (`V35 | `V36) -> `Active `Tier2
+    | `Fedora (`V36 | `V37) -> `Active `Tier2
     | `OracleLinux (`V7 | `V8) -> `Active `Tier3
     | `OpenSUSE (`V42_1 | `V42_2 | `V42_3 | `V15_0 | `V15_1 | `V15_2) ->
         `Deprecated
@@ -633,7 +636,7 @@ let distro_arches ov (d : t) =
     when OV.(compare Releases.v4_05_0 ov) = -1 ->
       let base = [ `X86_64; `Aarch64; `Ppc64le; `S390x ] in
       if OV.(compare Releases.v4_11_0 ov) <= 0 then `Riscv64 :: base else base
-  | `Fedora (`V33 | `V34 | `V35 | `V36), ov
+  | `Fedora (`V33 | `V34 | `V35 | `V36 | `V37), ov
     when OV.(compare Releases.v4_08_0 ov) = -1 ->
       [ `X86_64; `Aarch64 ]
   (* 2021-04-19: should be 4.03 but there's a linking failure until 4.06. *)
@@ -728,6 +731,7 @@ let builtin_ocaml_of_distro (d : t) : string option =
   | `Fedora `V34 -> Some "4.11.1"
   | `Fedora `V35 -> Some "4.12.0"
   | `Fedora `V36 -> Some "4.13.1"
+  | `Fedora `V37 -> Some "4.13.1"
   | `CentOS `V6 -> Some "3.11.2"
   | `CentOS `V7 -> Some "4.01.0"
   | `CentOS `V8 -> Some "4.07.0"
@@ -865,6 +869,7 @@ let tag_of_distro (d : t) =
   | `Fedora `V34 -> "fedora-34"
   | `Fedora `V35 -> "fedora-35"
   | `Fedora `V36 -> "fedora-36"
+  | `Fedora `V37 -> "fedora-37"
   | `OracleLinux `V7 -> "oraclelinux-7"
   | `OracleLinux `V8 -> "oraclelinux-8"
   | `OracleLinux `Latest -> "oraclelinux"
@@ -1036,6 +1041,7 @@ let human_readable_string_of_distro (d : t) =
     | `Fedora `V34 -> "Fedora 34"
     | `Fedora `V35 -> "Fedora 35"
     | `Fedora `V36 -> "Fedora 36"
+    | `Fedora `V37 -> "Fedora 37"
     | `OracleLinux `V7 -> "OracleLinux 7"
     | `OracleLinux `V8 -> "OracleLinux 8"
     | `Alpine `V3_3 -> "Alpine 3.3"
@@ -1161,6 +1167,7 @@ let rec bubblewrap_version (t : t) =
   | `Fedora `V34 -> Some (0, 4, 1)
   | `Fedora `V35 -> Some (0, 5, 0)
   | `Fedora `V36 -> Some (0, 5, 0)
+  | `Fedora `V37 -> Some (0, 5, 0)
   | `OracleLinux ((`V7 | `V8) as v) -> bubblewrap_version (`CentOS v)
   | `Alpine `V3_3 -> None (* Not actually checked *)
   | `Alpine `V3_4 -> None (* Not actually checked *)
@@ -1279,6 +1286,7 @@ let base_distro_tag ?win10_revision ?(arch = `X86_64) d =
         | `V34 -> "34"
         | `V35 -> "35"
         | `V36 -> "36"
+        | `V37 -> "37"
       in
       ("fedora", tag)
   | `OracleLinux v ->

--- a/src-opam/distro.mli
+++ b/src-opam/distro.mli
@@ -114,7 +114,8 @@ type distro =
     | `V33
     | `V34
     | `V35
-    | `V36 ]
+    | `V36
+    | `V37 ]
   | `OracleLinux of [ `V7 | `V8 ]
   | `OpenSUSE of [ `V42_1 | `V42_2 | `V42_3 | `V15_0 | `V15_1 | `V15_2 | `V15_3 ]
   | `Ubuntu of
@@ -178,6 +179,7 @@ type t =
     | `V34
     | `V35
     | `V36
+    | `V37
     | `Latest ]
   | `OracleLinux of [ `V7 | `V8 | `Latest ]
   | `OpenSUSE of


### PR DESCRIPTION
Fedora 37 is set to be released on 2022-11-01.
Fedora 35 is set to be EOL'd on 2022-11-29.

- [x] #125 