### PR TITLE
debian:10 does not provide ppc64 and s390x images anymore

### DIFF
--- a/src-opam/distro.ml
+++ b/src-opam/distro.ml
@@ -621,8 +621,6 @@ let distro_arches ov (d : t) =
       [ `I386; `X86_64; `Aarch64; `Aarch32; `Ppc64le; `S390x ]
   | `Debian `V11, ov when OV.(compare Releases.v4_02_0 ov) = -1 ->
       [ `I386; `X86_64; `Aarch64; `Aarch32 ]
-  | `Debian `V10, ov when OV.(compare Releases.v4_03_0 ov) = -1 ->
-      [ `I386; `X86_64; `Aarch64; `Aarch32; `Ppc64le; `S390x ]
   | `Debian `V10, ov when OV.(compare Releases.v4_02_0 ov) = -1 ->
       [ `I386; `X86_64; `Aarch64; `Aarch32 ]
   | `Debian `V9, ov when OV.(compare Releases.v4_03_0 ov) = -1 ->


### PR DESCRIPTION
See https://hub.docker.com/_/debian/tags?page=1&name=10