### PR TITLE
Support `RUN` command arguments (mounts, network, security)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
 unreleased
 ----------
 
+- Support mounts, networks, and security parameters in RUN
+  commands, add buildkit_syntax helper function.
+  (@MisterDA, @edwintorok, #137, #139, review by @edwintorok)
 - Build and install opam master from source in Windows images.
   (@MisterDA #140, #142, #143)
 - Include the ocaml-beta-repository in the images. (@kit-ty-kate #132, review by @MisterDA)

--- a/src/dockerfile.ml
+++ b/src/dockerfile.ml
@@ -114,7 +114,8 @@ let escape_string ~char_to_escape ~escape v =
   let buf = Buffer.create len in
   let j = ref 0 in
   for i = 0 to len - 1 do
-    if v.[i] = char_to_escape || v.[i] = escape then (
+    if String.unsafe_get v i = char_to_escape || String.unsafe_get v i = escape
+    then (
       if i - !j > 0 then Buffer.add_substring buf v !j (i - !j);
       Buffer.add_char buf escape;
       j := i)

--- a/src/dockerfile.ml
+++ b/src/dockerfile.ml
@@ -235,6 +235,7 @@ and string_of_healthcheck ~escape options c =
 
 (* Function interface *)
 let parser_directive pd : t = [ `ParserDirective pd ]
+let buildkit_syntax = parser_directive (`Syntax "docker/dockerfile:1")
 
 let heredoc ?(strip = false) ?(word = "EOF") ?(delimiter = word) fmt =
   ksprintf (fun here_document -> { here_document; strip; word; delimiter }) fmt

--- a/src/dockerfile.mli
+++ b/src/dockerfile.mli
@@ -121,25 +121,33 @@ val maintainer : ('a, unit, string, t) format4 -> 'a
 (** [maintainer] sets the author field of the generated images. *)
 
 type mount
+type network = [ `Default | `None | `Host ]
 
-val run : ?mounts:mount list -> ('a, unit, string, t) format4 -> 'a
+val run :
+  ?mounts:mount list -> ?network:network -> ('a, unit, string, t) format4 -> 'a
 (** [run ?mounts fmt] will execute any commands in a new layer on top of the
    current image and commit the results. The resulting committed image will be
    used for the next step in the Dockerfile. The string result of formatting
    [arg] will be passed as a [/bin/sh -c] invocation.
 
    @param mounts A list of filesystem mounts that the build can access. Requires
-     BuildKit {{!val:parser_directive}syntax} 1.2. *)
+     BuildKit {{!val:parser_directive}syntax} 1.2.
 
-val run_exec : ?mounts:mount list -> string list -> t
-(** [run_exec ?mounts args] will execute any commands in a new layer on top of
+   @param network Control which networking environment the command is run in.
+     Requires BuildKit {{!val:parser_directive}syntax} 1.1. *)
+
+val run_exec : ?mounts:mount list -> ?network:network -> string list -> t
+(** [run_exec ?mounts ?network args] will execute any commands in a new layer on top of
    the current image and commit the results. The resulting committed image will
    be used for the next step in the Dockerfile. The [args] form makes it
    possible to avoid shell string munging, and to run commands using a base
    image that does not contain [/bin/sh].
 
    @param mounts A list of filesystem mounts that the build can access. Requires
-     BuildKit {{!val:parser_directive}syntax} 1.2. *)
+     BuildKit {{!val:parser_directive}syntax} 1.2.
+
+   @param network Control which networking environment the command is run in.
+     Requires BuildKit {{!val:parser_directive}syntax} 1.1. *)
 
 val mount_bind :
   target:string ->
@@ -435,4 +443,4 @@ val crunch : t -> t
   one that is chained using the shell [&&] operator. This reduces the
   number of layers required for a production image.
 
-  @raise Invalid_argument if mounts differ for each run command. *)
+  @raise Invalid_argument if mounts or networks differ for each run command. *)

--- a/src/dockerfile.mli
+++ b/src/dockerfile.mli
@@ -58,7 +58,12 @@ type parser_directive = [ `Syntax of string | `Escape of char ]
 val parser_directive : parser_directive -> t
 (** A parser directive. If used, needs to be the first line of the
    Dockerfile.
-   @see <https://docs.docker.com/engine/reference/builder/#parser-directives> *)
+   @see <https://docs.docker.com/engine/reference/builder/#parser-directives>
+   @see <https://docs.docker.com/build/buildkit/dockerfile-frontend/> *)
+
+val buildkit_syntax : t
+(** Convenience function, returns the {{!val-parser_directive}parser directive}
+    describing the latest BuildKit syntax. *)
 
 val comment : ('a, unit, string, t) format4 -> 'a
 (** Adds a comment to the Dockerfile for documentation purposes *)

--- a/src/dockerfile.mli
+++ b/src/dockerfile.mli
@@ -122,32 +122,48 @@ val maintainer : ('a, unit, string, t) format4 -> 'a
 
 type mount
 type network = [ `Default | `None | `Host ]
+type security = [ `Insecure | `Sandbox ]
 
 val run :
-  ?mounts:mount list -> ?network:network -> ('a, unit, string, t) format4 -> 'a
-(** [run ?mounts fmt] will execute any commands in a new layer on top of the
-   current image and commit the results. The resulting committed image will be
-   used for the next step in the Dockerfile. The string result of formatting
-   [arg] will be passed as a [/bin/sh -c] invocation.
+  ?mounts:mount list ->
+  ?network:network ->
+  ?security:security ->
+  ('a, unit, string, t) format4 ->
+  'a
+(** [run ?mounts ?network ?security fmt] will execute any commands in a new
+   layer on top of the current image and commit the results. The resulting
+   committed image will be used for the next step in the Dockerfile. The string
+   result of formatting [arg] will be passed as a [/bin/sh -c] invocation.
 
    @param mounts A list of filesystem mounts that the build can access. Requires
      BuildKit {{!val:parser_directive}syntax} 1.2.
 
    @param network Control which networking environment the command is run in.
-     Requires BuildKit {{!val:parser_directive}syntax} 1.1. *)
+     Requires BuildKit {{!val:parser_directive}syntax} 1.1.
 
-val run_exec : ?mounts:mount list -> ?network:network -> string list -> t
-(** [run_exec ?mounts ?network args] will execute any commands in a new layer on top of
-   the current image and commit the results. The resulting committed image will
-   be used for the next step in the Dockerfile. The [args] form makes it
-   possible to avoid shell string munging, and to run commands using a base
-   image that does not contain [/bin/sh].
+   @param security Control which security mode the command is run in.
+     Requires BuildKit {{!val:parser_directive}syntax} 1-labs. *)
 
-   @param mounts A list of filesystem mounts that the build can access. Requires
-     BuildKit {{!val:parser_directive}syntax} 1.2.
+val run_exec :
+  ?mounts:mount list ->
+  ?network:network ->
+  ?security:security ->
+  string list ->
+  t
+(** [run_exec ?mounts ?network ?security args] will execute any commands in a
+   new layer on top of current image and commit the results. The resulting
+   committed image will be used for the next step in the Dockerfile. The [cmd]
+   form makes it possible to avoid shell string munging, and to run commands
+   using a base image that does not contain [/bin/sh].
 
-   @param network Control which networking environment the command is run in.
-     Requires BuildKit {{!val:parser_directive}syntax} 1.1. *)
+  @param mounts A list of filesystem mounts that the build can access. Requires
+    BuildKit syntax 1.2.
+
+  @param network Control which networking environment the command is run in.
+    Requires BuildKit {{!val:parser_directive}syntax} 1.1.
+
+  @param security Control which security mode the command is run in. Requires
+    BuildKit {{!val:parser_directive}syntax} 1-labs. *)
 
 val mount_bind :
   target:string ->
@@ -443,4 +459,5 @@ val crunch : t -> t
   one that is chained using the shell [&&] operator. This reduces the
   number of layers required for a production image.
 
-  @raise Invalid_argument if mounts or networks differ for each run command. *)
+  @raise Invalid_argument if mounts or networks or security modes differ for
+    each run command. *)

--- a/src/dockerfile.mli
+++ b/src/dockerfile.mli
@@ -81,7 +81,7 @@ val heredoc :
     [here_document] as content and [word] () as opening delimiter. If
     [word] is quoted, then [delimiter] (unquoted [word]) needs to be
     specified. Quoting affects expansion in the here-document.
-    Requires BuildKit 1.4 {{!val:parser_directive}syntax}.
+    Requires 1.4 {!val:buildkit_syntax}.
 
     @param strip Whether to strip leading tab characters. Defaults to false.
     @param word The opening delimiter, possibly quoted. Defaults to [EOF].
@@ -136,9 +136,10 @@ val run :
    result of formatting [arg] will be passed as a [/bin/sh -c] invocation.
 
    @param mounts A list of filesystem mounts that the build can access. Requires
-     BuildKit {{!val:parser_directive}syntax} 1.2.
+     {!val:buildkit_syntax} 1.2.
 
    @param network Control which networking environment the command is run in.
+     Requires {!val:buildkit_syntax} 1.1.
      Requires BuildKit {{!val:parser_directive}syntax} 1.1.
 
    @param security Control which security mode the command is run in.
@@ -157,10 +158,10 @@ val run_exec :
    using a base image that does not contain [/bin/sh].
 
   @param mounts A list of filesystem mounts that the build can access. Requires
-    BuildKit syntax 1.2.
+    {!val:buildkit_syntax} 1.2.
 
   @param network Control which networking environment the command is run in.
-    Requires BuildKit {{!val:parser_directive}syntax} 1.1.
+    Requires {!val:buildkit_syntax} 1.1.
 
   @param security Control which security mode the command is run in. Requires
     BuildKit {{!val:parser_directive}syntax} 1-labs. *)
@@ -172,7 +173,7 @@ val mount_bind :
   ?readwrite:bool ->
   unit ->
   mount
-(** Creates a bind mount for {!run}. Requires BuildKit syntax. *)
+(** Creates a bind mount for {!run}. Requires {!val:buildkit_syntax}. *)
 
 val mount_cache :
   ?id:string ->
@@ -186,10 +187,10 @@ val mount_cache :
   ?gid:int ->
   unit ->
   mount
-(** Creates a cache mount for {!run}. Requires BuildKit syntax. *)
+(** Creates a cache mount for {!run}. Requires {!val:buildkit_syntax}. *)
 
 val mount_tmpfs : target:string -> ?size:int -> unit -> mount
-(** Creates a tmpfs mount for {!run}. Requires BuildKit syntax. *)
+(** Creates a tmpfs mount for {!run}. Requires {!val:buildkit_syntax}. *)
 
 val mount_secret :
   ?id:string ->
@@ -200,7 +201,7 @@ val mount_secret :
   ?gid:int ->
   unit ->
   mount
-(** Creates a secret mount for {!run}. Requires BuildKit syntax. *)
+(** Creates a secret mount for {!run}. Requires {!val:buildkit_syntax}. *)
 
 val mount_ssh :
   ?id:string ->
@@ -211,7 +212,7 @@ val mount_ssh :
   ?gid:int ->
   unit ->
   mount
-(** Creates an ssh mount for {!run}. Requires BuildKit syntax. *)
+(** Creates an ssh mount for {!run}. Requires {!val:buildkit_syntax}. *)
 
 val cmd : ('a, unit, string, t) format4 -> 'a
 (** [cmd args] provides defaults for an executing container. These defaults
@@ -281,8 +282,8 @@ val add :
 
   @param link Add files with enhanced semantics where your files
     remain independent on their own layer and don’t get invalidated
-    when commands on previous layers are changed. Requires BuildKit
-    1.4 {{!val:parser_directive}syntax}.
+    when commands on previous layers are changed.
+    Requires 1.4 {!val:buildkit_syntax}.
 
   @param chown Specify a given username, groupname, or UID/GID
     combination to request specific ownership of the copied
@@ -308,8 +309,8 @@ val copy :
 
   @param link Copy files with enhanced semantics where your files
     remain independent on their own layer and don’t get invalidated
-    when commands on previous layers are changed. Requires BuildKit
-    1.4 {{!val:parser_directive}syntax}.
+    when commands on previous layers are changed.
+    Requires 1.4 {!val:buildkit_syntax}.
 
   @param chown Specify a given username, groupname, or UID/GID
     combination to request specific ownership of the copied content.
@@ -321,7 +322,8 @@ val copy :
 
 val copy_heredoc : ?chown:string -> src:heredoc list -> dst:string -> unit -> t
 (** [copy_heredoc src dst] creates the file [dst] using the content of
-    the here-documents [src]. Requires BuildKit 1.4 {{!val:parser_directive}syntax}.
+    the here-documents [src].
+    Requires 1.4 {!val:buildkit_syntax}.
 
     @see <https://github.com/moby/buildkit/blob/master/frontend/dockerfile/docs/syntax.md#here-documents> *)
 


### PR DESCRIPTION
This is a first attempt at supporting `RUN` command arguments. I've added types for mounts and networks which are in BuildKit, and security, which is not yet in BuildKit. I've added an escape hatch to `RUN` as the `?args:string list` parameter for later additions (and podman compat?). The security and network types, being relatively simple now, get their own parameters to `RUN`, but the mount values are serialized to string first.
The `crunch` function will not crunch shell scripts if their network or security differ, specified or not.
cc #137