### PR TITLE
Fixes to build and install opam master in Windows

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,7 @@
 unreleased
 ----------
 
-- Build and install opam master from source in Windows images. (@MisterDA #140)
+- Build and install opam master from source in Windows images. (@MisterDA #140, #142)
 - Include the ocaml-beta-repository in the images. (@kit-ty-kate #132, review by @MisterDA)
 - Add OpenSUSE 15.4, deprecate OpenSUSE 15.3. (@MisterDA #138)
 - Update to bubblewrap 0.7.0. (@MisterDA #131)

--- a/src-opam/windows.ml
+++ b/src-opam/windows.ml
@@ -192,7 +192,7 @@ module Cygwin = struct
         ]
       ~dst:{|C:\TEMP\msvs-tools.tar.gz|} ()
     @@ run_sh ~cyg
-         {|cd /tmp && tar -xf /cygdrive/c/TEMP/msvs-tools.tar.gz && cp msvs-tools-%s/msvs-detect msvs-tools-%s/msvs-promote-path /bin|}
+         {|cd /tmp && tar -xf /cygdrive/c/TEMP/msvs-tools.tar.gz && cp msvs-tools-%s/msvs-detect msvs-tools-%s/msvs-promote-path /bin && rm -rf /cygdrive/c/TEMP/msvs-tools/*|}
          version version
 
   let cygsetup ?(cyg = default) ?(upgrade = false) fmt =


### PR DESCRIPTION
Simplify, don't use cold compiler, install opam private runtime.