### PR TITLE
Install system packages required by OCaml 5.1+ in the ocaml stage 

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
 unreleased
 ----------
 
+- Install system packages required by OCaml in the ocaml stage,
+  starting with OCaml 5.1 and libzstd.
+  (@MisterDA #149, review by @kit-ty-kate)
 - Add OracleLinux 9. (@MisterDA #155)
 - Optimize and fix Linux package install.
   (@MisterDA #147, #151, #153, #154, review by @kit-ty-kate)

--- a/src-opam/linux.ml
+++ b/src-opam/linux.ml
@@ -45,6 +45,11 @@ module RPM = struct
        libX11-devel which m4 diffutils findutils%s"
       (match extra with None -> "" | Some x -> " " ^ x)
 
+  let ocaml_depexts v =
+    if Ocaml_version.compare v Ocaml_version.Releases.v5_1_0 >= 0 then
+      Some "zstd"
+    else None
+
   let add_user ?uid ?gid ?(sudo = false) username =
     let uid = match uid with Some u -> sprintf "-u %d " u | None -> "" in
     let gid = match gid with Some g -> sprintf "-g %d " g | None -> "" in
@@ -90,6 +95,11 @@ module Apt = struct
           libx11-dev%s"
          (match extra with None -> "" | Some x -> " " ^ x)
 
+  let ocaml_depexts v =
+    if Ocaml_version.compare v Ocaml_version.Releases.v5_1_0 >= 0 then
+      Some "libzstd-dev"
+    else None
+
   let add_user ?uid ?gid ?(sudo = false) username =
     let uid = match uid with Some u -> sprintf "--uid %d " u | None -> "" in
     let gid = match gid with Some g -> sprintf "--gid %d " g | None -> "" in
@@ -124,6 +134,11 @@ module Apk = struct
       "build-base patch tar ca-certificates git rsync curl sudo bash \
        libx11-dev nano coreutils xz ncurses-dev%s"
       (match extra with None -> "" | Some x -> " " ^ x)
+
+  let ocaml_depexts v =
+    if Ocaml_version.compare v Ocaml_version.Releases.v5_1_0 >= 0 then
+      Some "zstd"
+    else None
 
   let add_user ?uid ?gid ?(sudo = false) username =
     let home = "/home/" ^ username in
@@ -180,6 +195,11 @@ module Zypper = struct
           rsync gzip%s"
          (match extra with None -> "" | Some x -> " " ^ x)
 
+  let ocaml_depexts v =
+    if Ocaml_version.compare v Ocaml_version.Releases.v5_1_0 >= 0 then
+      Some "zstd"
+    else None
+
   let add_user ?uid ?gid ?(sudo = false) username =
     let home = "/home/" ^ username in
     run "useradd %s%s -d %s -m --user-group %s"
@@ -215,6 +235,11 @@ module Pacman = struct
       "make gcc patch tar ca-certificates git rsync curl sudo bash libx11 nano \
        coreutils xz ncurses diffutils unzip%s"
       (match extra with None -> "" | Some x -> " " ^ x)
+
+  let ocaml_depexts v =
+    if Ocaml_version.compare v Ocaml_version.Releases.v5_1_0 >= 0 then
+      Some "zstd"
+    else None
 
   let add_user ?uid ?gid ?(sudo = false) username =
     let home = "/home/" ^ username in

--- a/src-opam/linux.mli
+++ b/src-opam/linux.mli
@@ -48,6 +48,10 @@ module RPM : sig
   (** [dev_packages ?extra ()] will install the base development tools and [sudo],
       [passwd] and [git].  Extra packages may also be optionally supplied via [extra]. *)
 
+  val ocaml_depexts : Ocaml_version.t -> string option
+  (** [ocaml_depexts v] returns packages that are required by the
+      OCaml distribution at version [v]. *)
+
   val install_system_ocaml : t
   (** Install the system OCaml packages via Yum *)
 end
@@ -69,6 +73,10 @@ module Apt : sig
   (** [dev_packages ?extra ()] will install the base development tools and [sudo],
       [passwd] and [git] and X11.  Extra packages may also be optionally supplied via [extra]. *)
 
+  val ocaml_depexts : Ocaml_version.t -> string option
+  (** [ocaml_depexts v] returns packages that are required by the
+      OCaml distribution at version [v]. *)
+
   val install_system_ocaml : t
   (** Install the system OCaml packages via [apt-get] *)
 end
@@ -84,6 +92,10 @@ module Apk : sig
   val dev_packages : ?extra:string -> unit -> t
   (** [dev_packages ?extra ()] will install the base development tools and [sudo],
       [passwd] and [git].  Extra packages may also be optionally supplied via [extra]. *)
+
+  val ocaml_depexts : Ocaml_version.t -> string option
+  (** [ocaml_depexts v] returns packages that are required by the
+      OCaml distribution at version [v]. *)
 
   val add_user : ?uid:int -> ?gid:int -> ?sudo:bool -> string -> t
   (** [add_user username] will install a new user with name [username] and a locked
@@ -117,6 +129,10 @@ module Zypper : sig
   (** [dev_packages ?extra ()] will install the base development tools and [sudo],
       [passwd] and [git].  Extra packages may also be optionally supplied via [extra]. *)
 
+  val ocaml_depexts : Ocaml_version.t -> string option
+  (** [ocaml_depexts v] returns packages that are required by the
+      OCaml distribution at version [v]. *)
+
   val install_system_ocaml : t
   (** Install the system OCaml packages via [zypper] *)
 end
@@ -137,6 +153,10 @@ module Pacman : sig
   val dev_packages : ?extra:string -> unit -> t
   (** [dev_packages ?extra ()] will install the base development tools and [sudo],
       [passwd] and [git].  Extra packages may also be optionally supplied via [extra]. *)
+
+  val ocaml_depexts : Ocaml_version.t -> string option
+  (** [ocaml_depexts v] returns packages that are required by the
+      OCaml distribution at version [v]. *)
 
   val install_system_ocaml : t
   (** Install the system OCaml packages via [pacman] *)

--- a/src-opam/opam.ml
+++ b/src-opam/opam.ml
@@ -507,6 +507,24 @@ let gen_opam2_distro ?win10_revision ?winget ?(clone_opam_repo = true) ?arch
   in
   (D.tag_of_distro d, fn @@ clone @@ pers)
 
+let ocaml_depexts distro v =
+  let open Linux in
+  match D.package_manager distro with
+  | `Apk ->
+      Option.fold ~none:empty ~some:(Apk.install "%s") (Apk.ocaml_depexts v)
+  | `Apt ->
+      Option.fold ~none:empty ~some:(Apt.install "%s") (Apt.ocaml_depexts v)
+  | `Yum ->
+      Option.fold ~none:empty ~some:(RPM.install "%s") (RPM.ocaml_depexts v)
+  | `Zypper ->
+      Option.fold ~none:empty ~some:(Zypper.install "%s")
+        (Zypper.ocaml_depexts v)
+  | `Pacman ->
+      Option.fold ~none:empty ~some:(Pacman.install "%s")
+        (Pacman.ocaml_depexts v)
+  | `Windows -> empty
+  | `Cygwin -> empty
+
 let create_switch ~arch distro t =
   let create_switch switch pkg =
     run "opam switch create %s %s" (OV.to_string switch) pkg

--- a/src-opam/opam.mli
+++ b/src-opam/opam.mli
@@ -68,6 +68,11 @@ val gen_opam2_distro :
    will be build in an prepended build stage. If specified, then
    winget will be pulled from the [winget] external image. *)
 
+val ocaml_depexts : Distro.t -> Ocaml_version.t -> Dockerfile.t
+(** [ocaml_depexts distro version] returns packages that are
+    required under [distro] by the OCaml distribution at version
+    [version].  *)
+
 val all_ocaml_compilers :
   string -> Ocaml_version.arch -> Distro.t -> string * Dockerfile.t
 (** [all_ocaml_compilers hub_id arch distro] will generate an opam2


### PR DESCRIPTION
Different releases of OCaml require different system libraries: libX11 isn't needed since 4.09, when the Graphics library was moved from the core distribution to a separate package. On the opposite side, OCaml 5.1 can optionally use libzstd for compressing marshalled data. Install these packages accordingly in the ocaml image.