### PR TITLE
Optimise and fix Linux packages installation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 unreleased
 ----------
 
+- Optimize and fix Linux package install (@MisterDA #153)
 - Switch to ocaml-opam/opam-repository-mingw#sunset for Windows images. (@MisterDA #152)
 - Use DockerHub user risvc64/ubuntu. (@MisterDA, #150)
 - Various LCU Updates (@mtelvers #144 #136 #135)

--- a/src-opam/linux.ml
+++ b/src-opam/linux.ml
@@ -39,6 +39,13 @@ module RPM = struct
   let groupinstall fmt =
     ksprintf (fun s -> run "yum groupinstall -y %s && yum clean all" s) fmt
 
+  let dev_packages ?extra () =
+    install
+      "sudo passwd bzip2 patch rsync nano gcc-c++ git tar curl xz libX11-devel \
+       which m4 diffutils findutils%s"
+      (match extra with None -> "" | Some x -> " " ^ x)
+    @@ groupinstall "\"Development Tools\""
+
   let add_user ?uid ?gid ?(sudo = false) username =
     let uid = match uid with Some u -> sprintf "-u %d " u | None -> "" in
     let gid = match gid with Some g -> sprintf "-g %d " g | None -> "" in
@@ -59,13 +66,6 @@ module RPM = struct
     @@ user "%s" username
     @@ env [ ("HOME", home) ]
     @@ workdir "%s" home @@ run "mkdir .ssh" @@ run "chmod 700 .ssh"
-
-  let dev_packages ?extra () =
-    install
-      "sudo passwd bzip2 patch rsync nano gcc-c++ git tar curl xz libX11-devel \
-       which m4 diffutils findutils%s"
-      (match extra with None -> "" | Some x -> " " ^ x)
-    @@ groupinstall "\"Development Tools\""
 
   let install_system_ocaml = install "ocaml ocaml-camlp4-devel ocaml-ocamldoc"
 end

--- a/src-opam/linux.ml
+++ b/src-opam/linux.ml
@@ -177,8 +177,8 @@ module Zypper = struct
     install "-t pattern devel_C_C++"
     @@ install
          "sudo git unzip curl gcc-c++ libcap-devel xz libX11-devel bzip2 which \
-          rsync gzip"
-    @@ maybe (install "%s") extra
+          rsync gzip%s"
+         (match extra with None -> "" | Some x -> " " ^ x)
 
   let add_user ?uid ?gid ?(sudo = false) username =
     let home = "/home/" ^ username in

--- a/src-opam/linux.ml
+++ b/src-opam/linux.ml
@@ -32,10 +32,12 @@ let sudo_nopasswd = "ALL=(ALL:ALL) NOPASSWD:ALL"
 (** RPM rules *)
 module RPM = struct
   let update = run "yum update -y"
-  let install fmt = ksprintf (run "yum install -y %s && yum clean all") fmt
+
+  let install fmt =
+    ksprintf (fun s -> update @@ run "yum install -y %s && yum clean all" s) fmt
 
   let groupinstall fmt =
-    ksprintf (run "yum groupinstall -y %s && yum clean all") fmt
+    ksprintf (fun s -> run "yum groupinstall -y %s && yum clean all" s) fmt
 
   let add_user ?uid ?gid ?(sudo = false) username =
     let uid = match uid with Some u -> sprintf "-u %d " u | None -> "" in
@@ -59,11 +61,11 @@ module RPM = struct
     @@ workdir "%s" home @@ run "mkdir .ssh" @@ run "chmod 700 .ssh"
 
   let dev_packages ?extra () =
-    groupinstall "\"Development Tools\""
-    @@ install
-         "sudo passwd bzip2 patch rsync nano gcc-c++ git tar curl xz \
-          libX11-devel which m4 diffutils findutils%s"
-         (match extra with None -> "" | Some x -> " " ^ x)
+    install
+      "sudo passwd bzip2 patch rsync nano gcc-c++ git tar curl xz libX11-devel \
+       which m4 diffutils findutils%s"
+      (match extra with None -> "" | Some x -> " " ^ x)
+    @@ groupinstall "\"Development Tools\""
 
   let install_system_ocaml = install "ocaml ocaml-camlp4-devel ocaml-ocamldoc"
 end

--- a/src-opam/linux.ml
+++ b/src-opam/linux.ml
@@ -204,8 +204,12 @@ end
 
 (** Pacman rules *)
 module Pacman = struct
-  let update = run "pacman -Syu --noconfirm"
-  let install fmt = ksprintf (fun s -> run "pacman -Syu --noconfirm %s" s) fmt
+  let update = run "pacman -Syu --noconfirm && yes | pacman -Scc"
+
+  let install fmt =
+    ksprintf
+      (fun s -> run "pacman -Syu --noconfirm %s && yes | pacman -Scc" s)
+      fmt
 
   let dev_packages ?extra () =
     install

--- a/src-opam/linux.ml
+++ b/src-opam/linux.ml
@@ -147,7 +147,7 @@ module Apk = struct
     @@ user "%s" username @@ workdir "%s" home @@ run "mkdir .ssh"
     @@ run "chmod 700 .ssh"
 
-  let install_system_ocaml = run "apk add ocaml camlp4"
+  let install_system_ocaml = install "ocaml camlp4"
 
   let add_repository ?tag url =
     run "<<-EOF cat >> /etc/apk/repositories\n\t%s\nEOF"

--- a/src-opam/linux.ml
+++ b/src-opam/linux.ml
@@ -83,10 +83,9 @@ module Apt = struct
       fmt
 
   let dev_packages ?extra () =
-    update
-    @@ copy_heredoc
-         ~src:[ heredoc ~strip:true "\tAcquire::Retries \"5\";" ]
-         ~dst:"/etc/apt/apt.conf.d/mirror-retry" ()
+    copy_heredoc
+      ~src:[ heredoc ~strip:true "\tAcquire::Retries \"5\";" ]
+      ~dst:"/etc/apt/apt.conf.d/mirror-retry" ()
     @@ install
          "build-essential curl git rsync sudo unzip nano libcap-dev \
           libx11-dev%s"

--- a/src-opam/linux.ml
+++ b/src-opam/linux.ml
@@ -230,5 +230,5 @@ module Pacman = struct
     @@ user "%s" username @@ workdir "%s" home @@ run "mkdir .ssh"
     @@ run "chmod 700 .ssh"
 
-  let install_system_ocaml = run "pacman add ocaml ocaml-compiler-libs"
+  let install_system_ocaml = install "ocaml ocaml-compiler-libs"
 end

--- a/src-opam/opam.ml
+++ b/src-opam/opam.ml
@@ -350,14 +350,15 @@ let yum_opam2 ?(labels = []) ?arch ~yum_workaround ~enable_powertools
   header ?arch distro
   @@ label (("distro_style", "rpm") :: labels)
   @@ run "yum --version || dnf install -y yum"
-  @@ workaround @@ Linux.RPM.update
-  @@ Linux.RPM.dev_packages ~extra:"which tar curl xz libcap-devel openssl" ()
+  @@ workaround
+  @@ Linux.RPM.install "which tar curl xz libcap-devel openssl sudo"
+  @@ Linux.RPM.groupinstall {|"Development Tools"|}
   @@ Linux.Git.init ()
   @@ maybe_build_bubblewrap_from_source distro
   @@ install_opams ~prefix:"/usr" opam_master_hash opam_branches
   @@ from ?arch distro
   @@ run "yum --version || dnf install -y yum"
-  @@ workaround @@ Linux.RPM.update
+  @@ workaround
   @@ bubblewrap_and_dev_packages distro
   @@ copy_opams ~src:"/usr/bin" ~dst:"/usr/bin" opam_branches
   @@ (if enable_powertools then


### PR DESCRIPTION
Try to reorder calls to update the package lists, upgrade the current installed packages, and install new packages to minimize network calls. Some fixes along the way. Make sure that installing packages updates the package lists first.
Most package managers don't have a package download cache enabled, but pacman does. Cleaning the pacman dl cache recovers ~112M (with libx11 as a dependency, YMMV: depends whether new packages have been published since the build of the base image).
Some package managers require package lists to be available before upgrading/installing packages (apt), others will automatically download them. Be conservative, and keep the package lists in all cases.
opam can't download the package lists if the package manager doesn't do it automatically, and will fail the `opam depext` install if so.
There's no particular need to crunch the lines into simpler layers, since the images are later squashed.