### PR TITLE
Switch to root then opam user to fix ocaml depexts install

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,15 +1,22 @@
+unreleased
+----------
+
+- Switch to root and back to opam user when installing OCaml external
+  dependencies in the ocaml stage; fixes depext installation.
+  (@MisterDA #146, #157)
+
 v8.2.0 2023-03-23 Berlin
 ------------------------
 
 - Install system packages required by OCaml in the ocaml stage,
   starting with OCaml 5.1 and libzstd.
-  (@MisterDA #149, review by @kit-ty-kate)
+  (@MisterDA #146, #149, review by @kit-ty-kate)
 - Add OracleLinux 9. (@MisterDA #155)
 - Optimize and fix Linux package install.
   (@MisterDA #147, #151, #153, #154, review by @kit-ty-kate)
 - Switch to ocaml-opam/opam-repository-mingw#sunset for Windows images. (@MisterDA #152)
 - Use DockerHub user risvc64/ubuntu. (@MisterDA, #150)
-- Various LCU Updates (@mtelvers #144 #136 #135)
+- Various LCU Updates (@mtelvers #156 #144 #136 #135)
 - Support mounts, networks, and security parameters in RUN
   commands, add buildkit_syntax helper function.
   (@MisterDA, @edwintorok, #137, #139, review by @edwintorok)

--- a/src-opam/opam.ml
+++ b/src-opam/opam.ml
@@ -509,19 +509,16 @@ let gen_opam2_distro ?win10_revision ?winget ?(clone_opam_repo = true) ?arch
 
 let ocaml_depexts distro v =
   let open Linux in
+  let as_root install = function
+    | Some depexts -> user "root" @@ install depexts @@ user "opam"
+    | None -> empty
+  in
   match D.package_manager distro with
-  | `Apk ->
-      Option.fold ~none:empty ~some:(Apk.install "%s") (Apk.ocaml_depexts v)
-  | `Apt ->
-      Option.fold ~none:empty ~some:(Apt.install "%s") (Apt.ocaml_depexts v)
-  | `Yum ->
-      Option.fold ~none:empty ~some:(RPM.install "%s") (RPM.ocaml_depexts v)
-  | `Zypper ->
-      Option.fold ~none:empty ~some:(Zypper.install "%s")
-        (Zypper.ocaml_depexts v)
-  | `Pacman ->
-      Option.fold ~none:empty ~some:(Pacman.install "%s")
-        (Pacman.ocaml_depexts v)
+  | `Apk -> as_root (Apk.install "%s") (Apk.ocaml_depexts v)
+  | `Apt -> as_root (Apt.install "%s") (Apt.ocaml_depexts v)
+  | `Yum -> as_root (RPM.install "%s") (RPM.ocaml_depexts v)
+  | `Zypper -> as_root (Zypper.install "%s") (Zypper.ocaml_depexts v)
+  | `Pacman -> as_root (Pacman.install "%s") (Pacman.ocaml_depexts v)
   | `Windows -> empty
   | `Cygwin -> empty
 


### PR DESCRIPTION
Switch to root and back to opam user when installing OCaml external dependencies in the ocaml stage; fixes depext installation.
cf https://github.com/ocurrent/docker-base-images/pull/220