### PR TITLE
Correct sexp generation for `dockerfile-opam`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
 unreleased
 ----------
 
+- Correct sexp generation for dockerfile-opam.
+  (@benmandrew #158, review by @MisterDA)
+
 - Switch to root and back to opam user when installing OCaml external
   dependencies in the ocaml stage; fixes depext installation.
   (@MisterDA #146, #157)

--- a/src-opam/dune
+++ b/src-opam/dune
@@ -4,6 +4,4 @@
  (synopsis "Dockerfile functions to generate opam2 base containers")
  (libraries ocaml-version dockerfile fmt sexplib astring)
  (preprocess
-  (per_module
-   ((pps ppx_sexp_conv)
-    dockerfile_distro))))
+  (pps ppx_sexp_conv)))


### PR DESCRIPTION
For sexp ppx, the `dune` file in `dockerfile-opam` still expects the old `dockerfile_distro` layout and thus the s-expression converters are not generated for `distro.ml`.