### PR TITLE
Make docstring indentation consistent + some docs rewording

### DIFF
--- a/src-cmd/dockerfile_cmd.mli
+++ b/src-cmd/dockerfile_cmd.mli
@@ -40,7 +40,7 @@ val run_log :
   Bos.Cmd.t ->
   (unit, [> `Msg of string ]) result
 (** [runlog log_dir name cmd] will run [cmd] with label [name]
-   and log the results in [<log_dir>/<name>.sxp]. *)
+    and log the results in [<log_dir>/<name>.sxp]. *)
 
 (** Docker command invocation *)
 module Docker : sig

--- a/src-opam/distro.mli
+++ b/src-opam/distro.mli
@@ -146,7 +146,7 @@ type distro =
   | `Cygwin of win10_release
   | `Windows of [ `Mingw | `Msvc ] * win10_release ]
 [@@deriving sexp]
-(** Supported Docker container distributions distributions. *)
+(** Supported Docker container distributions without aliases. *)
 
 type t =
   [ `Alpine of
@@ -223,7 +223,7 @@ type t =
   | `Cygwin of win_all
   | `Windows of [ `Mingw | `Msvc ] * win_all ]
 [@@deriving sexp]
-(** Supported Docker container distributions. *)
+(** Supported Docker container distributions with aliases such as [Latest]. *)
 
 type os_family = [ `Cygwin | `Linux | `Windows ] [@@deriving sexp]
 (** The operating system family a distro belongs to. *)
@@ -237,22 +237,22 @@ val os_family_to_string : os_family -> string
 
 val opam_repository : os_family -> string
 (** [opam_repository os_family] returns the git URL to the default
-   Opam repository. *)
+    Opam repository. *)
 
 val personality : os_family -> Ocaml_version.arch -> string option
 (** [personality os_family arch] returns the personality associated to
-   the architecture, if [os_family] is [`Linux]. *)
+    the architecture, if [os_family] is [`Linux]. *)
 
 val is_same_distro : t -> t -> bool
 (** [is_same_distro d1 d2] returns whether [d1] is the same distro as
-   [d2], regardless of their respective versions. *)
+    [d2], regardless of their respective versions. *)
 
 val compare : t -> t -> int
 (** [compare a b] is a lexical comparison function for {!t}. *)
 
 val resolve_alias : t -> distro
 (** [resolve_alias t] will resolve [t] into a concrete version. This removes
-   versions such as [Latest]. *)
+    versions such as [Latest]. *)
 
 val distros : t list
 (** Enumeration of the supported Docker container distributions. *)
@@ -265,8 +265,8 @@ val win10_latest_release : win10_release
 
 val win10_latest_image : win10_release
 (** Latest Windows 10 Docker image available. May differ from
-   {!win10_latest_release} if the Docker repository hasn't been
-   updated. *)
+    {!win10_latest_release} if the Docker repository hasn't been
+    updated. *)
 
 val master_distro : t
 (** The distribution that is the top-level alias for the [latest] tag
@@ -274,16 +274,16 @@ val master_distro : t
 
 val builtin_ocaml_of_distro : t -> string option
 (** [builtin_ocaml_of_distro t] will return the OCaml version
-  supplied with the distribution packaging, and [None] if there
-  is no supported version. *)
+    supplied with the distribution packaging, and [None] if there
+    is no supported version. *)
 
 val human_readable_string_of_distro : t -> string
 (** [human_readable_string_of_distro t] returns a human readable
-  version of the distribution tag, including version information. *)
+    version of the distribution tag, including version information. *)
 
 val human_readable_short_string_of_distro : t -> string
 (** [human_readable_short_string_of_distro t] returns a human readable
-  short version of the distribution tag, excluding version information. *)
+    short version of the distribution tag, excluding version information. *)
 
 type package_manager =
   [ `Apk  (** Alpine Apk *)
@@ -297,13 +297,13 @@ type package_manager =
 (** The package manager used by a distro. *)
 
 val package_manager : t -> package_manager
-(** [package_manager t] returns the type of package manager used
- by that distribution.  Many derived distributions (such as OracleLinux)
- share the same package manager from a base distribution (such as CentOS). *)
+(** [package_manager t] returns the package manager used by that distribution.
+    Many derived distributions (such as OracleLinux) share the same package
+    manager from a base distribution (such as CentOS). *)
 
 val bubblewrap_version : t -> (int * int * int) option
 (** [bubblewrap_version t] returns the version of bubblewrap available on that
- distribution. *)
+    distribution. *)
 
 (** {2 Docker Hub addresses} *)
 
@@ -316,10 +316,10 @@ val distro_of_tag : string -> t option
 
 val latest_tag_of_distro : t -> string
 (** [latest_tag_of_distro distro] will generate a Docker Hub
-  tag that is a convenient short form for the latest stable
-  release of a particular distribution.  This tag will be
-  regularly rewritten to point to any new releases of the
-  distribution. *)
+    tag that is a convenient short form for the latest stable
+    release of a particular distribution.  This tag will be
+    regularly rewritten to point to any new releases of the
+    distribution. *)
 
 type win10_docker_base_image =
   [ `NanoServer  (** Windows Nano Server *)
@@ -334,28 +334,28 @@ val win10_base_tag :
   win_all ->
   string * string
 (** [win10_base_tag base_image release] will return a tuple of Windows
-   container base image and tag for which the base image of a Windows
-   base image can be found (e.g.
-   [mcr.microsoft.com/windows/servercore],[ltsc2022] which maps to
-   [mcr.microsoft.com/windows/servercore:ltsc2022] on the Microsoft
-   Container Registry). *)
+    container base image and tag for which the base image of a Windows
+    base image can be found (e.g.
+    [mcr.microsoft.com/windows/servercore],[ltsc2022] which maps to
+    [mcr.microsoft.com/windows/servercore:ltsc2022] on the Microsoft
+    Container Registry). *)
 
 val base_distro_tag :
   ?win10_revision:win10_lcu -> ?arch:Ocaml_version.arch -> t -> string * string
 (** [base_distro_tag ?arch t] will return a tuple of a Docker Hub
- user/repository and tag for which the base image of a distribution
- can be found (e.g. [opensuse/leap],[15.0] which maps to [opensuse/leap:15.0]
- on the Docker Hub).  This base image is in turn can be used to generate opam
- and other OCaml tool Dockerfiles. [arch] defaults to [x86_64] and can vary
- the base user/repository since some architecture are built elsewhere. *)
+    user/repository and tag for which the base image of a distribution
+    can be found (e.g. [opensuse/leap],[15.0] which maps to [opensuse/leap:15.0]
+    on the Docker Hub).  This base image is in turn can be used to generate opam
+    and other OCaml tool Dockerfiles. [arch] defaults to [x86_64] and can vary
+    the base user/repository since some architecture are built elsewhere. *)
 
 val win10_release_to_string : win10_release -> string
 (** [win10_release_to_string update] converts a Windows 10 version name to
-   string. *)
+    string. *)
 
 val win10_release_of_string : string -> win_all option
 (** [win10_release_of_string] converts a Windows 10 version name as
-   string to its internal representation. Ignores any KB number. *)
+    string to its internal representation. Ignores any KB number. *)
 
 val win10_revision_to_string : win10_revision -> string
 val win10_revision_of_string : string -> win10_revision option
@@ -378,8 +378,8 @@ type win10_release_status = [ `Deprecated | `Active ]
 
 val win10_release_status : win_all -> win10_release_status
 (** [win10_release_status v channel] returns the Microsoft support
-   status of the specified Windows 10 release.
-   @see <https://en.wikipedia.org/wiki/Windows_10_version_history#Channels> *)
+    status of the specified Windows 10 release.
+    @see <https://en.wikipedia.org/wiki/Windows_10_version_history#Channels> *)
 
 val active_distros : Ocaml_version.arch -> t list
 (** [active_distros arch] returns the list of currently supported

--- a/src-opam/distro.mli
+++ b/src-opam/distro.mli
@@ -223,7 +223,7 @@ type t =
   | `Cygwin of win_all
   | `Windows of [ `Mingw | `Msvc ] * win_all ]
 [@@deriving sexp]
-(** Supported Docker container distributions with aliases such as [Latest]. *)
+(** Supported Docker container distributions with aliases such as [`Latest]. *)
 
 type os_family = [ `Cygwin | `Linux | `Windows ] [@@deriving sexp]
 (** The operating system family a distro belongs to. *)

--- a/src-opam/opam.mli
+++ b/src-opam/opam.mli
@@ -56,17 +56,17 @@ val gen_opam2_distro :
   Distro.t ->
   string * Dockerfile.t
 (** [gen_opam2_distro ~opam_hashes d] will generate a Dockerfile
-   for Linux distribution [d] with opam 2.0, opam 2.1, opam 2.2 and opam master,
-   per hash given in parameter.
-   @return a tuple of the Docker tag and the Dockerfile.
-   If [clone_opam_repo] is true (the default) then the Dockerfile will also git
-   clone the official opam-repository into [/home/opam/opam-repository].
-   If [arch] is not specified, it defaults to the base image that is assumed
-   to be multiarch (the main exception to this is i386, which requires different
-   base images from amd64).
-   For native Windows distributions, if [winget] is omitted, then winget
-   will be build in an prepended build stage. If specified, then
-   winget will be pulled from the [winget] external image. *)
+    for Linux distribution [d] with opam 2.0, opam 2.1, opam 2.2 and opam master,
+    per hash given in parameter.
+    @return a tuple of the Docker tag and the Dockerfile.
+    If [clone_opam_repo] is true (the default) then the Dockerfile will also git
+    clone the official opam-repository into [/home/opam/opam-repository].
+    If [arch] is not specified, it defaults to the base image that is assumed
+    to be multiarch (the main exception to this is i386, which requires different
+    base images from amd64).
+    For native Windows distributions, if [winget] is omitted, then winget
+    will be build in an prepended build stage. If specified, then
+    winget will be pulled from the [winget] external image. *)
 
 val ocaml_depexts : Distro.t -> Ocaml_version.t -> Dockerfile.t
 (** [ocaml_depexts distro version] returns packages that are
@@ -76,21 +76,21 @@ val ocaml_depexts : Distro.t -> Ocaml_version.t -> Dockerfile.t
 val all_ocaml_compilers :
   string -> Ocaml_version.arch -> Distro.t -> string * Dockerfile.t
 (** [all_ocaml_compilers hub_id arch distro] will generate an opam2
-  container that has all the recent OCaml compilers installed into a
-  distribution [distro] on architecture [arch]. *)
+    container that has all the recent OCaml compilers installed into a
+    distribution [distro] on architecture [arch]. *)
 
 val separate_ocaml_compilers :
   string -> Ocaml_version.arch -> Distro.t -> (string * Dockerfile.t) list
 (** [separate_ocaml_compilers hub_id arch distro] will install a list of
-  Dockerfiles that build individual OCaml compiler versions and their
-  variants (e.g. flambda) in separate containers. *)
+    Dockerfiles that build individual OCaml compiler versions and their
+    variants (e.g. flambda) in separate containers. *)
 
 val deprecated : Dockerfile.t
 (** [deprecated] is a minimal container that outputs a deprecation error. This
-   is used to replace unsupported containers on the Hub rather than leaving an
-   unmaintained distribution lying around with possible security holes. *)
+    is used to replace unsupported containers on the Hub rather than leaving an
+    unmaintained distribution lying around with possible security holes. *)
 
 val multiarch_manifest :
   target:string -> platforms:(string * string) list -> string
 (** [multiarch_manifest ~target ~platforms] will generate a manifest-tool compliant yaml file to
-  build a [target] on the given multiarch [platforms]. *)
+    build a [target] on the given multiarch [platforms]. *)

--- a/src-opam/windows.mli
+++ b/src-opam/windows.mli
@@ -26,18 +26,18 @@ val run_powershell :
   ?escape:(string -> string) -> ('a, unit, string, t) format4 -> 'a
 (** [run_powershell fmt] will execute [powershell -Command "fmt"].
 
-    @param escape (defaults to {!Fun.id}) allows to escape [fmt]
-      because the calling shell (usually [cmd]) might interpret
-      unwanted things in [fmt]. This might help embedding readable
-      powershell code. *)
+      @param escape (defaults to {!Fun.id}) allows to escape [fmt]
+        because the calling shell (usually [cmd]) might interpret
+        unwanted things in [fmt]. This might help embedding readable
+        powershell code. *)
 
 val run_vc : arch:Ocaml_version.arch -> ('a, unit, string, t) format4 -> 'a
 (** [run_vc ~arch fmt] will execute [run fmt] with Visual
-   Compiler for [~arch] loaded in the environment. *)
+    Compiler for [~arch] loaded in the environment. *)
 
 val run_ocaml_env : string list -> ('a, unit, string, t) format4 -> 'a
 (** [run_ocaml_env args fmt] will execute [fmt] in the environment
-   loaded by [ocaml-env exec] with [args]. *)
+    loaded by [ocaml-env exec] with [args]. *)
 
 val sanitize_reg_path : unit -> t
   [@@ocaml.doc
@@ -53,11 +53,11 @@ val sanitize_reg_path : unit -> t
 
 val install_vc_redist : ?vs_version:string -> unit -> t
 (** Install Microsoft Visual C++ Redistributable.
-   @see <https://support.microsoft.com/en-us/help/2977003/the-latest-supported-visual-c-downloads> *)
+    @see <https://support.microsoft.com/en-us/help/2977003/the-latest-supported-visual-c-downloads> *)
 
 val install_visual_studio_build_tools : ?vs_version:string -> string list -> t
 (** Install Visual Studio Build Tools components.
-   @see <https://docs.microsoft.com/en-us/visualstudio/install/workload-component-id-vs-build-tools?view=vs-2019> *)
+    @see <https://docs.microsoft.com/en-us/visualstudio/install/workload-component-id-vs-build-tools?view=vs-2019> *)
 
 val ocaml_for_windows_package_exn :
   switch:Ocaml_version.t ->
@@ -65,8 +65,8 @@ val ocaml_for_windows_package_exn :
   arch:Ocaml_version.arch ->
   string * string
 (** [ocaml_for_windows_variant ~port ~arch] returns the
-   [(package_name, package_version)] of the OCaml compiler
-   package in OCaml for Windows, if applicable. *)
+    [(package_name, package_version)] of the OCaml compiler
+    package in OCaml for Windows, if applicable. *)
 
 val remove_system_attribute : ?recurse:bool -> string -> t
 (** Remove the system attribute on a path. Might be useful to copy
@@ -86,34 +86,33 @@ module Cygwin : sig
     root : string;  (** Root installation directory *)
     site : string;  (** Download site URL *)
     args : string list;
-        (** List of arguments to give to Cygwin's setup, except
-           [--root] and [--site]. *)
   }
+  (** List of arguments to give to Cygwin's setup, except [--root] and [--site]. *)
 
   val default : cyg
   (** The default Cygwin root, mirror, and arguments. *)
 
   val install_from_release :
     ?cyg:cyg -> ?msvs_tools:bool -> ?extra:string list -> unit -> Dockerfile.t
-  (** Install Cygwin with CygSymPathy and optionally msvs-tools, and [extra] Cygwin
-     packages (first in a separate Docker image). Sets the
-     [CYGWIN=winsymlinks:native] environment variable.
-     @see <https://github.com/metastack/cygsympathy>
-     @see <https://github.com/metastack/msvs-tools> *)
+  (** Install Cygwin with CygSymPathy and optionally msvs-tools,
+      and [extra] Cygwin packages (first in a separate Docker image).
+      Sets the [CYGWIN=winsymlinks:native] environment variable.
+      @see <https://github.com/metastack/cygsympathy>
+      @see <https://github.com/metastack/msvs-tools> *)
 
   val setup : ?cyg:cyg -> ?from:string -> unit -> t
   (** Setup winget, optionally copied from the [from] Docker image.  *)
 
   val install : ?cyg:cyg -> string list -> Dockerfile.t
   (** Install the supplied Cygwin package list. The packages should be
-     comma-separated. *)
+      comma-separated. *)
 
   val update : ?cyg:cyg -> unit -> t
   (** Update Cygwin packages. *)
 
   val cygwin_packages : ?flexdll_version:string -> unit -> string list
   (** [cygwin_packages ?extra ()] is the list of the base development
-     tools for the OCaml Cygwin port. *)
+      tools for the OCaml Cygwin port. *)
 
   val mingw_packages : string list
   (** [mingw_packages] is the list of base development tools for the
@@ -126,18 +125,18 @@ module Cygwin : sig
   val ocaml_for_windows_packages :
     ?cyg:cyg -> ?extra:string list -> ?version:string -> unit -> string list * t
   (** [ocaml_for_windows_packages ?extra ()] returns the list of
-     Cygwin packages dependencies, and the installation instructions.
-     Extra packages may also be optionally supplied via [extra].
-     @see <https://fdopen.github.io/opam-repository-mingw/> *)
+      Cygwin packages dependencies, and the installation instructions.
+      Extra packages may also be optionally supplied via [extra].
+      @see <https://fdopen.github.io/opam-repository-mingw/> *)
 
   val run_sh : ?cyg:cyg -> ('a, unit, string, t) format4 -> 'a
   (** [run_sh ?cyg fmt] will execute in the Cygwin root
-     [\bin\bash.exe --login -c "fmt"]. *)
+      [\bin\bash.exe --login -c "fmt"]. *)
 
   val run_sh_ocaml_env :
     ?cyg:cyg -> string list -> ('a, unit, string, t) format4 -> 'a
   (** [run_cmd_ocaml_env args fmt] will execute [fmt] in the environment
-     loaded by [ocaml-env cygwin exec] with [args]. *)
+      loaded by [ocaml-env cygwin exec] with [args]. *)
 
   (** Rules for Git. *)
   module Git : sig
@@ -150,9 +149,9 @@ module Cygwin : sig
       t
     (** Configure the git name and email variables to sensible defaults.
 
-       @param repos A list of paths to Git repos to mark as safe
-         directories. Defaults to the default location of the
-         opam-repository. *)
+        @param repos A list of paths to Git repos to mark as safe
+          directories. Defaults to the default location of the
+          opam-repository. *)
   end
 end
 
@@ -161,12 +160,12 @@ end
 module Winget : sig
   val is_supported : Distro.win_all -> bool
   (** Winget 1.0.11692 discontinued support for versions older than
-     Windows 10 1809. Older versions of Winget have bugs, don't use
-     them. *)
+      Windows 10 1809. Older versions of Winget have bugs, don't use
+      them. *)
 
   val install_from_release : ?winget_version:string -> unit -> t
   (** Install winget from a released build (first in a separate Docker
-     image). The optional [winget_version] specifies a Git tag. *)
+      image). The optional [winget_version] specifies a Git tag. *)
 
   val setup : ?from:string -> unit -> t
   (** Setup winget, optionally copied from the [from] Docker
@@ -185,8 +184,8 @@ module Winget : sig
     val init : ?name:string -> ?email:string -> ?repos:string list -> unit -> t
     (** Configure the git name and email variables to sensible defaults.
 
-       @param repos A list of paths to Git repos to mark as safe
-         directories. Defaults to the default location of the
-         opam-repository. *)
+        @param repos A list of paths to Git repos to mark as safe
+          directories. Defaults to the default location of the
+          opam-repository. *)
   end
 end

--- a/src/dockerfile.mli
+++ b/src/dockerfile.mli
@@ -57,9 +57,9 @@ type parser_directive = [ `Syntax of string | `Escape of char ]
 
 val parser_directive : parser_directive -> t
 (** A parser directive. If used, needs to be the first line of the
-   Dockerfile.
-   @see <https://docs.docker.com/engine/reference/builder/#parser-directives>
-   @see <https://docs.docker.com/build/buildkit/dockerfile-frontend/> *)
+    Dockerfile.
+    @see <https://docs.docker.com/engine/reference/builder/#parser-directives>
+    @see <https://docs.docker.com/build/buildkit/dockerfile-frontend/> *)
 
 val buildkit_syntax : t
 (** Convenience function, returns the {{!val-parser_directive}parser directive}
@@ -131,19 +131,19 @@ val run :
   ('a, unit, string, t) format4 ->
   'a
 (** [run ?mounts ?network ?security fmt] will execute any commands in a new
-   layer on top of the current image and commit the results. The resulting
-   committed image will be used for the next step in the Dockerfile. The string
-   result of formatting [arg] will be passed as a [/bin/sh -c] invocation.
+    layer on top of the current image and commit the results. The resulting
+    committed image will be used for the next step in the Dockerfile. The string
+    result of formatting [arg] will be passed as a [/bin/sh -c] invocation.
 
-   @param mounts A list of filesystem mounts that the build can access. Requires
-     {!val:buildkit_syntax} 1.2.
+    @param mounts A list of filesystem mounts that the build can access. Requires
+      {!val:buildkit_syntax} 1.2.
 
-   @param network Control which networking environment the command is run in.
-     Requires {!val:buildkit_syntax} 1.1.
-     Requires BuildKit {{!val:parser_directive}syntax} 1.1.
+    @param network Control which networking environment the command is run in.
+      Requires {!val:buildkit_syntax} 1.1.
+      Requires BuildKit {{!val:parser_directive}syntax} 1.1.
 
-   @param security Control which security mode the command is run in.
-     Requires BuildKit {{!val:parser_directive}syntax} 1-labs. *)
+    @param security Control which security mode the command is run in.
+      Requires BuildKit {{!val:parser_directive}syntax} 1-labs. *)
 
 val run_exec :
   ?mounts:mount list ->
@@ -152,19 +152,19 @@ val run_exec :
   string list ->
   t
 (** [run_exec ?mounts ?network ?security args] will execute any commands in a
-   new layer on top of current image and commit the results. The resulting
-   committed image will be used for the next step in the Dockerfile. The [cmd]
-   form makes it possible to avoid shell string munging, and to run commands
-   using a base image that does not contain [/bin/sh].
+    new layer on top of current image and commit the results. The resulting
+    committed image will be used for the next step in the Dockerfile. The [cmd]
+    form makes it possible to avoid shell string munging, and to run commands
+    using a base image that does not contain [/bin/sh].
 
-  @param mounts A list of filesystem mounts that the build can access. Requires
-    {!val:buildkit_syntax} 1.2.
+    @param mounts A list of filesystem mounts that the build can access. Requires
+      {!val:buildkit_syntax} 1.2.
 
-  @param network Control which networking environment the command is run in.
-    Requires {!val:buildkit_syntax} 1.1.
+    @param network Control which networking environment the command is run in.
+      Requires {!val:buildkit_syntax} 1.1.
 
-  @param security Control which security mode the command is run in. Requires
-    BuildKit {{!val:parser_directive}syntax} 1-labs. *)
+    @param security Control which security mode the command is run in. Requires
+      BuildKit {{!val:parser_directive}syntax} 1-labs. *)
 
 val mount_bind :
   target:string ->
@@ -247,7 +247,7 @@ val mount_secret :
 
     Requires {!buildkit_syntax}.
 
- @see <https://docs.docker.com/engine/reference/builder/#run---mounttypesecret> Docker --mount=type=secret reference
+    @see <https://docs.docker.com/engine/reference/builder/#run---mounttypesecret> Docker --mount=type=secret reference
 *)
 
 val mount_ssh :
@@ -270,29 +270,29 @@ val mount_ssh :
 
 val cmd : ('a, unit, string, t) format4 -> 'a
 (** [cmd args] provides defaults for an executing container. These defaults
-  can include an executable, or they can omit the executable, in which case
-  you must specify an {!entrypoint} as well.  The string result of formatting
-  [arg] will be passed as a [/bin/sh -c] invocation.
+    can include an executable, or they can omit the executable, in which case
+    you must specify an {!entrypoint} as well.  The string result of formatting
+    [arg] will be passed as a [/bin/sh -c] invocation.
 
-  There can only be one [cmd] in a Dockerfile. If you list more than one
-  then only the last [cmd] will take effect. *)
+    There can only be one [cmd] in a Dockerfile. If you list more than one
+    then only the last [cmd] will take effect. *)
 
 val cmd_exec : string list -> t
 (** [cmd_exec args] provides defaults for an executing container. These defaults
-  can include an executable, or they can omit the executable, in which case
-  you must specify an {!entrypoint} as well.  The first argument to the [args]
-  list must be the full path to the executable.
+    can include an executable, or they can omit the executable, in which case
+    you must specify an {!entrypoint} as well.  The first argument to the [args]
+    list must be the full path to the executable.
 
-  There can only be one [cmd] in a Dockerfile. If you list more than one
-  then only the last [cmd] will take effect. *)
+    There can only be one [cmd] in a Dockerfile. If you list more than one
+    then only the last [cmd] will take effect. *)
 
 val expose_port : int -> t
 (** [expose_port] informs Docker that the container will listen on the specified
-  network port at runtime. *)
+    network port at runtime. *)
 
 val expose_ports : int list -> t
 (** [expose_ports] informs Docker that the container will listen on the specified
-  network ports at runtime. *)
+    network ports at runtime. *)
 
 val arg : ?default:string -> string -> t
 (** [arg ~default name] defines a variable that users can pass at
@@ -302,9 +302,9 @@ val arg : ?default:string -> string -> t
 
 val env : (string * string) list -> t
 (** [env] sets the list of environment variables supplied with the
-  (<key>, <value>) tuple. This value will be passed to all future {!run}
-  instructions. This is functionally equivalent to prefixing a shell
-  command with [<key>=<value>]. *)
+    (<key>, <value>) tuple. This value will be passed to all future {!run}
+    instructions. This is functionally equivalent to prefixing a shell
+    command with [<key>=<value>]. *)
 
 val add :
   ?link:bool ->
@@ -318,35 +318,35 @@ val add :
     directories or remote file URLs from [src] and adds them to the
     filesystem of the container at the [dst] path.
 
-  Multiple [src] resource may be specified but if they are files or
-  directories then they must be relative to the source directory that
-  is being built (the context of the build).
+    Multiple [src] resource may be specified but if they are files or
+    directories then they must be relative to the source directory that
+    is being built (the context of the build).
 
-  Each [src] may contain wildcards and matching will be done using
-  Go's filepath.Match rules.
+    Each [src] may contain wildcards and matching will be done using
+    Go's filepath.Match rules.
 
-  All new files and directories are created with a UID and GID of 0.
-  In the case where [src] is a remote file URL, the destination will
-  have permissions of 600. If the remote file being retrieved has an
-  HTTP Last-Modified header, the timestamp from that header will be
-  used to set the mtime on the destination file. Then, like any other
-  file processed during an ADD, mtime will be included in the
-  determination of whether or not the file has changed and the cache
-  should be updated.
+    All new files and directories are created with a UID and GID of 0.
+    In the case where [src] is a remote file URL, the destination will
+    have permissions of 600. If the remote file being retrieved has an
+    HTTP Last-Modified header, the timestamp from that header will be
+    used to set the mtime on the destination file. Then, like any other
+    file processed during an ADD, mtime will be included in the
+    determination of whether or not the file has changed and the cache
+    should be updated.
 
-  @param link Add files with enhanced semantics where your files
-    remain independent on their own layer and don’t get invalidated
-    when commands on previous layers are changed.
-    Requires 1.4 {!val:buildkit_syntax}.
+    @param link Add files with enhanced semantics where your files
+      remain independent on their own layer and don’t get invalidated
+      when commands on previous layers are changed.
+      Requires 1.4 {!val:buildkit_syntax}.
 
-  @param chown Specify a given username, groupname, or UID/GID
-    combination to request specific ownership of the copied
-    content.
+    @param chown Specify a given username, groupname, or UID/GID
+      combination to request specific ownership of the copied
+      content.
 
-  @param from Allows artefacts to be retrieved from multiple
-    stages. It can either be an integer number (starting with 0 for
-    the first {!from} stage, or a named stage (supplied via [?alias]
-    to the {!from} command). *)
+    @param from Allows artefacts to be retrieved from multiple
+      stages. It can either be an integer number (starting with 0 for
+      the first {!from} stage, or a named stage (supplied via [?alias]
+      to the {!from} command). *)
 
 val copy :
   ?link:bool ->
@@ -361,18 +361,18 @@ val copy :
     container at the path [dst]. See {!add} for more detailed
     documentation.
 
-  @param link Copy files with enhanced semantics where your files
-    remain independent on their own layer and don’t get invalidated
-    when commands on previous layers are changed.
-    Requires 1.4 {!val:buildkit_syntax}.
+    @param link Copy files with enhanced semantics where your files
+      remain independent on their own layer and don’t get invalidated
+      when commands on previous layers are changed.
+      Requires 1.4 {!val:buildkit_syntax}.
 
-  @param chown Specify a given username, groupname, or UID/GID
-    combination to request specific ownership of the copied content.
+    @param chown Specify a given username, groupname, or UID/GID
+      combination to request specific ownership of the copied content.
 
-  @param from Allows artefacts to be retrieved from multiple
-    stages. It can either be an integer number (starting with 0 for
-    the first {!from} stage, or a named stage (supplied via [?alias]
-    to the {!from} command). *)
+    @param from Allows artefacts to be retrieved from multiple
+      stages. It can either be an integer number (starting with 0 for
+      the first {!from} stage, or a named stage (supplied via [?alias]
+      to the {!from} command). *)
 
 val copy_heredoc : ?chown:string -> src:heredoc list -> dst:string -> unit -> t
 (** [copy_heredoc src dst] creates the file [dst] using the content of
@@ -383,50 +383,50 @@ val copy_heredoc : ?chown:string -> src:heredoc list -> dst:string -> unit -> t
 
 val user : ('a, unit, string, t) format4 -> 'a
 (** [user fmt] sets the user name or UID to use when running the image
-  and for any {!run}, {!cmd}, {!entrypoint} commands that follow it in
-  the Dockerfile.  *)
+    and for any {!run}, {!cmd}, {!entrypoint} commands that follow it in
+    the Dockerfile.  *)
 
 val workdir : ('a, unit, string, t) format4 -> 'a
 (** [workdir fmt] sets the working directory for any {!run}, {!cmd}
-  and {!entrypoint} instructions that follow it in the Dockerfile.
+    and {!entrypoint} instructions that follow it in the Dockerfile.
 
-  It can be used multiple times in the one Dockerfile. If a relative
-  path is provided, it will be relative to the path of the previous
-  {!workdir} instruction. *)
+    It can be used multiple times in the one Dockerfile. If a relative
+    path is provided, it will be relative to the path of the previous
+    {!workdir} instruction. *)
 
 val volume : ('a, unit, string, t) format4 -> 'a
 (** [volume fmt] will create a mount point with the specified name
-  and mark it as holding externally mounted volumes from native host
-  or other containers. The value can be a JSON array or a plain string
-  with multiple arguments that specify several mount points. *)
+    and mark it as holding externally mounted volumes from native host
+    or other containers. The value can be a JSON array or a plain string
+    with multiple arguments that specify several mount points. *)
 
 val volumes : string list -> t
 (** [volumes mounts] will create mount points with the specified names
-  in [mounts] and mark them as holding externally mounted volumes
-  from native host or other containers. *)
+    in [mounts] and mark them as holding externally mounted volumes
+    from native host or other containers. *)
 
 val entrypoint : ('a, unit, string, t) format4 -> 'a
 (** [entrypoint fmt] allows you to configure a container that will
-  run as an executable.  The [fmt] string will be executed using
-  a [/bin/sh] subshell.
+    run as an executable.  The [fmt] string will be executed using
+    a [/bin/sh] subshell.
 
-  The shell form prevents any {!cmd} or {!run} command line arguments
-  from being used, but has the disadvantage that your {!entrypoint}
-  will be started as a subcommand of [/bin/sh -c], which does not pass
-  signals. This means that the executable will not be the container's
-  PID 1 - and will not receive Unix signals - so your executable will
-  not receive a SIGTERM from [docker stop <container>].
+    The shell form prevents any {!cmd} or {!run} command line arguments
+    from being used, but has the disadvantage that your {!entrypoint}
+    will be started as a subcommand of [/bin/sh -c], which does not pass
+    signals. This means that the executable will not be the container's
+    PID 1 - and will not receive Unix signals - so your executable will
+    not receive a SIGTERM from [docker stop <container>].
 
-  To get around this limitation, use the {!entrypoint_exec} command
-  to directly execute an argument list without a subshell.
+    To get around this limitation, use the {!entrypoint_exec} command
+    to directly execute an argument list without a subshell.
 *)
 
 val entrypoint_exec : string list -> t
 (** [entrypoint fmt] allows you to configure a container that will
-  run as an executable.  You can use the exec form here to set fairly
-  stable default commands and arguments and then use either {!cmd} or
-  {!cmd_exec} to set additional defaults that are more likely to be changed
-  by the user starting the Docker container. *)
+    run as an executable.  You can use the exec form here to set fairly
+    stable default commands and arguments and then use either {!cmd} or
+    {!cmd_exec} to set additional defaults that are more likely to be changed
+    by the user starting the Docker container. *)
 
 val shell : string list -> t
 (** [shell t] allows the default shell used for the shell form of
@@ -438,30 +438,30 @@ val shell : string list -> t
 
 val onbuild : t -> t
 (** [onbuild t] adds to the image a trigger instruction [t] to be
-  executed at a later time, when the image is used as the base for
-  another build. The trigger will be executed in the context of the
-  downstream build, as if it had been inserted immediately after the
-  {!from} instruction in the downstream Dockerfile.
+    executed at a later time, when the image is used as the base for
+    another build. The trigger will be executed in the context of the
+    downstream build, as if it had been inserted immediately after the
+    {!from} instruction in the downstream Dockerfile.
 
-  Any build instruction can be registered as a trigger.
+    Any build instruction can be registered as a trigger.
 
-  This is useful if you are building an image which will be used as a
-  base to build other images, for example an application build environment
-  or a daemon which may be customized with user-specific configuration. *)
+    This is useful if you are building an image which will be used as a
+    base to build other images, for example an application build environment
+    or a daemon which may be customized with user-specific configuration. *)
 
 val label : (string * string) list -> t
 (** [label l] adds metadata to an image via a list of key-value pairs.
-  To include spaces within a label value, use quotes and backslashes as
-  you would in command-line parsing. An image can have more than one label.
-  To specify multiple labels, Docker recommends combining labels into a
-  single label instruction where possible. Each label instruction produces
-  a new layer which can result in an inefficient image if you use many labels.
+    To include spaces within a label value, use quotes and backslashes as
+    you would in command-line parsing. An image can have more than one label.
+    To specify multiple labels, Docker recommends combining labels into a
+    single label instruction where possible. Each label instruction produces
+    a new layer which can result in an inefficient image if you use many labels.
 
-  Labels are additive including [LABEL]s in [FROM] images. If Docker
-  encounters a label/key that already exists, the new value overrides any
-  previous labels with identical keys.
+    Labels are additive including [LABEL]s in [FROM] images. If Docker
+    encounters a label/key that already exists, the new value overrides any
+    previous labels with identical keys.
 
-  To view an image’s labels, use the [docker inspect] command. *)
+    To view an image’s labels, use the [docker inspect] command. *)
 
 val healthcheck :
   ?interval:string ->
@@ -471,24 +471,24 @@ val healthcheck :
   ('a, unit, string, t) format4 ->
   'a
 (** [healthcheck cmd] checks container health by running a command
-  inside the container. See {!cmd} for additional details.
+    inside the container. See {!cmd} for additional details.
 
-  @param interval The health check will first run [interval] seconds
-    after the container is started, and then again [interval] seconds
-    after each previous check completes.
+    @param interval The health check will first run [interval] seconds
+      after the container is started, and then again [interval] seconds
+      after each previous check completes.
 
-  @param timeout If a single run of the check takes longer than
-    [timeout] seconds then the check is considered to have failed.
+    @param timeout If a single run of the check takes longer than
+      [timeout] seconds then the check is considered to have failed.
 
-  @param retries It takes [retries] consecutive failures of the health
-    check for the container to be considered {i unhealthy}.
+    @param retries It takes [retries] consecutive failures of the health
+      check for the container to be considered {i unhealthy}.
 
-  @param start_period provides initialization time for containers that
-    need time to bootstrap. Probe failure during that period will not
-    be counted towards the maximum number of retries. However, if a
-    health check succeeds during the start period, the container is
-    considered started and all consecutive failures will be counted
-    towards the maximum number of retries.  *)
+    @param start_period provides initialization time for containers that
+      need time to bootstrap. Probe failure during that period will not
+      be counted towards the maximum number of retries. However, if a
+      health check succeeds during the start period, the container is
+      considered started and all consecutive failures will be counted
+      towards the maximum number of retries.  *)
 
 val healthcheck_exec :
   ?interval:string ->
@@ -498,13 +498,13 @@ val healthcheck_exec :
   string list ->
   t
 (** [healthcheck_exec cmd] checks container health by running a
-  command inside the container. See {!cmd_exec} and {!healthcheck}
-  for additional details.
+    command inside the container. See {!cmd_exec} and {!healthcheck}
+    for additional details.
 *)
 
 val healthcheck_none : unit -> t
 (** [healthcheck_none] disables any healthcheck inherited from the
-  base image. *)
+    base image. *)
 
 val stopsignal : string -> t
 (** [stopsignal signal] sets the system call signal that will be
@@ -512,8 +512,8 @@ val stopsignal : string -> t
 
 val crunch : t -> t
 (** [crunch t] will reduce coincident {!run} commands into a single
-  one that is chained using the shell [&&] operator. This reduces the
-  number of layers required for a production image.
+    one that is chained using the shell [&&] operator. This reduces the
+    number of layers required for a production image.
 
-  @raise Invalid_argument if mounts or networks or security modes differ for
-    each run command. *)
+    @raise Invalid_argument if mounts or networks or security modes differ for
+      each run command. *)


### PR DESCRIPTION
Docstrings are inconsistently indented, so picked one.

Is there a reason we don't use `ocamlformat`?