### PR TITLE
Update to bubblewrap 0.9.0

### DIFF
--- a/src-opam/distro.ml
+++ b/src-opam/distro.ml
@@ -1343,7 +1343,7 @@ let bubblewrap_version (t : t) =
   | `Debian `V11 -> Some (0, 4, 1)
   | `Debian `V12 -> Some (0, 8, 0)
   | `Debian `Testing -> Some (0, 8, 0)
-  | `Debian `Unstable -> Some (0, 8, 0)
+  | `Debian `Unstable -> Some (0, 9, 0)
   | `CentOS `V6 -> None
   | `CentOS `V7 -> None
   | `CentOS `V8 -> Some (0, 4, 0)
@@ -1387,7 +1387,7 @@ let bubblewrap_version (t : t) =
   | `Alpine `V3_17 -> Some (0, 7, 0)
   | `Alpine `V3_18 -> Some (0, 8, 0)
   | `Alpine `V3_19 -> Some (0, 8, 0)
-  | `Archlinux `Latest -> Some (0, 8, 0)
+  | `Archlinux `Latest -> Some (0, 9, 0)
   | `OpenSUSE `V42_1 -> None (* Not actually checked *)
   | `OpenSUSE `V42_2 -> None (* Not actually checked *)
   | `OpenSUSE `V42_3 -> None (* Not actually checked *)
@@ -1397,7 +1397,7 @@ let bubblewrap_version (t : t) =
   | `OpenSUSE `V15_3 -> Some (0, 4, 1)
   | `OpenSUSE `V15_4 -> Some (0, 4, 1)
   | `OpenSUSE `V15_5 -> Some (0, 7, 0)
-  | `OpenSUSE `Tumbleweed -> Some (0, 8, 0)
+  | `OpenSUSE `Tumbleweed -> Some (0, 9, 0)
   | `Cygwin _ -> None
   | `Windows _ -> None
 

--- a/src-opam/opam.ml
+++ b/src-opam/opam.ml
@@ -83,7 +83,7 @@ let install_opam_from_source_windows ?cyg ?prefix
        {|cd /usr/local/bin && tar -cf /cygdrive/c/opam.tar .|}
 
 let bubblewrap_minimum = (0, 4, 1)
-let bubblewrap_latest = (0, 8, 0)
+let bubblewrap_latest = (0, 9, 0)
 
 let maybe_build_bubblewrap_from_source ?(prefix = "/usr/local") distro =
   match D.bubblewrap_version distro with
@@ -99,8 +99,8 @@ let maybe_build_bubblewrap_from_source ?(prefix = "/usr/local") distro =
       in
       run "curl -fOL %s" url @@ run "tar xf %s" file
       @@ run
-           "cd bubblewrap-%s && ./configure --prefix=%s && make && sudo make \
-            install"
+           "cd bubblewrap-%s && ./autogen.sh && ./configure --prefix=%s && \
+            make && sudo make install"
            rel prefix
       @@ run "rm -rf %s bubblewrap-%s" file rel
 


### PR DESCRIPTION
> Building this version of bubblewrap with Meson is recommended. The source release `bubblewrap-0.9.0.tar.xz` no longer contains Autotools-generated files, although this version can still be built using Autotools after running `./autogen.sh`. Future versions are likely to remove the Autotools build system altogether.

https://github.com/containers/bubblewrap/releases/tag/v0.9.0

Not tested.