### PR TITLE
Deprecate Debian 10

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 unreleased
 ----------
 
+- Deprecate Debian 10. (@shonfeder, #210)
 - Add Ubuntu 24.04. (@mtelvers, #205)
 - Add Fedora 40, deprecate Fedora 37. (@mtelvers, #203)
 - Add Fedora 39. (@MisterDA #200)

--- a/src-opam/distro.ml
+++ b/src-opam/distro.ml
@@ -385,8 +385,8 @@ let distro_status (d : t) : status =
     | `Archlinux `Latest -> `Active `Tier3
     | `CentOS `V7 -> `Active `Tier3
     | `CentOS (`V6 | `V8) -> `Deprecated
-    | `Debian (`V7 | `V8 | `V9) -> `Deprecated
-    | `Debian (`V10 | `V11) -> `Active `Tier2
+    | `Debian (`V7 | `V8 | `V9 | `V10) -> `Deprecated
+    | `Debian `V11 -> `Active `Tier2
     | `Debian `V12 -> `Active `Tier1
     | `Debian `Testing -> `Active `Tier3
     | `Debian `Unstable -> `Active `Tier3


### PR DESCRIPTION
Depian 10 LTS reaches end of life on June 30th (see https://lists.debian.org/debian-lts-announce/2024/05/msg00002.html).

This should be merged at that time, and then updates propagated through our CI services.

Pleases let me know if there is anything else I should change!