### PR TITLE
Deprecate Fedora 38

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 unreleased
 ----------
 
+- Deprecate Fedora 38. (@mtelvers, #211)
 - Add Ubuntu 24.04. (@mtelvers, #205)
 - Add Fedora 40, deprecate Fedora 37. (@mtelvers, #203)
 - Add Fedora 39. (@MisterDA #200)

--- a/src-opam/distro.ml
+++ b/src-opam/distro.ml
@@ -392,9 +392,9 @@ let distro_status (d : t) : status =
     | `Debian `Unstable -> `Active `Tier3
     | `Fedora
         ( `V21 | `V22 | `V23 | `V24 | `V25 | `V26 | `V27 | `V28 | `V29 | `V30
-        | `V31 | `V32 | `V33 | `V34 | `V35 | `V36 | `V37 ) ->
+        | `V31 | `V32 | `V33 | `V34 | `V35 | `V36 | `V37 | `V38 ) ->
         `Deprecated
-    | `Fedora (`V38 | `V39 | `V40) -> `Active `Tier2
+    | `Fedora (`V39 | `V40) -> `Active `Tier2
     | `OracleLinux `V7 -> `Deprecated
     | `OracleLinux (`V8 | `V9) -> `Active `Tier3
     | `OpenSUSE


### PR DESCRIPTION
Fedora 38 went EOL as of 21st May 2024.

See https://docs.fedoraproject.org/en-US/releases/eol/