### PR TITLE
Deprecate Ubuntu 23.04

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 unreleased
 ----------
 
+- Deprecate Ubuntu 23.04. (@punchagan, #213)
 - Add Ubuntu 24.04. (@mtelvers, #205)
 - Add Fedora 40, deprecate Fedora 37. (@mtelvers, #203)
 - Add Fedora 39. (@MisterDA #200)

--- a/src-opam/distro.ml
+++ b/src-opam/distro.ml
@@ -403,12 +403,11 @@ let distro_status (d : t) : status =
         `Deprecated
     | `OpenSUSE `V15_6 -> `Active `Tier2
     | `OpenSUSE `Tumbleweed -> `Active `Tier2
-    | `Ubuntu (`V20_04 | `V22_04 | `V23_04 | `V23_10 | `V24_04) ->
-        `Active `Tier2
+    | `Ubuntu (`V20_04 | `V22_04 | `V23_10 | `V24_04) -> `Active `Tier2
     | `Ubuntu
         ( `V12_04 | `V14_04 | `V15_04 | `V15_10 | `V16_04 | `V16_10 | `V17_04
         | `V17_10 | `V18_04 | `V18_10 | `V19_04 | `V19_10 | `V20_10 | `V21_04
-        | `V21_10 | `V22_10 ) ->
+        | `V21_10 | `V22_10 | `V23_04 ) ->
         `Deprecated
     | `Cygwin (`Ltsc2016 | `Ltsc2019) -> `Deprecated
     | `Cygwin `Ltsc2022 -> `Active `Tier3


### PR DESCRIPTION
Ubuntu 23.04 is past its EoL since 2024-01-20

It might be good to merge this PR, alongside #210 and #211 if we are updating the git submodules of all our CI repos. 