### PR TITLE
Deprecated Ubuntu 23.10

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 unreleased
 ----------
 
+- Deprecate Ubuntu 23.10. (@mtelvers, #214)
 - Deprecate Ubuntu 23.04. (@punchagan, #213)
 - Deprecate Fedora 38. (@mtelvers, #211)
 - Deprecate Debian 10. (@shonfeder, #210)

--- a/src-opam/distro.ml
+++ b/src-opam/distro.ml
@@ -403,11 +403,11 @@ let distro_status (d : t) : status =
         `Deprecated
     | `OpenSUSE `V15_6 -> `Active `Tier2
     | `OpenSUSE `Tumbleweed -> `Active `Tier2
-    | `Ubuntu (`V20_04 | `V22_04 | `V23_10 | `V24_04) -> `Active `Tier2
+    | `Ubuntu (`V20_04 | `V22_04 | `V24_04) -> `Active `Tier2
     | `Ubuntu
         ( `V12_04 | `V14_04 | `V15_04 | `V15_10 | `V16_04 | `V16_10 | `V17_04
         | `V17_10 | `V18_04 | `V18_10 | `V19_04 | `V19_10 | `V20_10 | `V21_04
-        | `V21_10 | `V22_10 | `V23_04 ) ->
+        | `V21_10 | `V22_10 | `V23_04 | `V23_10 ) ->
         `Deprecated
     | `Cygwin (`Ltsc2016 | `Ltsc2019) -> `Deprecated
     | `Cygwin `Ltsc2022 -> `Active `Tier3


### PR DESCRIPTION
Ubuntu 23.10 will be EOL on 11th July.