### PR TITLE
Drop ppc64le and s390x

### DIFF
--- a/src-opam/distro.ml
+++ b/src-opam/distro.ml
@@ -440,9 +440,11 @@ module OV = Ocaml_version
 let distro_arches ov (d : t) =
   match (resolve_alias d, ov) with
   | (`CentOS (`V6 | `V7) | `OracleLinux `V7), ov when OV.major ov >= 5 -> []
-  | `Debian (`V11 | `V12), ov when OV.(compare Releases.v4_03_0 ov) = -1 ->
+  | `Debian `V12, ov when OV.(compare Releases.v4_03_0 ov) = -1 ->
       [ `I386; `X86_64; `Aarch64; `Aarch32; `Ppc64le; `S390x ]
-  | `Debian (`V11 | `V12), ov when OV.(compare Releases.v4_02_0 ov) = -1 ->
+  | `Debian `V12, ov when OV.(compare Releases.v4_02_0 ov) = -1 ->
+      [ `I386; `X86_64; `Aarch64; `Aarch32 ]
+  | `Debian `V11, ov when OV.(compare Releases.v4_02_0 ov) = -1 ->
       [ `I386; `X86_64; `Aarch64; `Aarch32 ]
   | `Debian `V10, ov when OV.(compare Releases.v4_03_0 ov) = -1 ->
       [ `I386; `X86_64; `Aarch64; `Aarch32 ]


### PR DESCRIPTION
> The Debian 11 life cycle encompasses five years: the initial three years of full Debian support, until August 14th, 2024, and two years of Long Term Support (LTS), until August 31st, 2026. The set of supported architectures is limited during the Bullseye LTS term to i386, amd64, armhf and arm64.

We are now in the LTS period; ppc64le and s390x have been dropped.