### PR TITLE
Fix for Fedora 41

### DIFF
--- a/src-opam/linux.ml
+++ b/src-opam/linux.ml
@@ -36,8 +36,18 @@ module RPM = struct
   let install fmt =
     ksprintf (fun s -> run "yum install -y %s && yum clean packages" s) fmt
 
-  let groupinstall fmt =
-    ksprintf (fun s -> run "yum groupinstall -y %s && yum clean packages" s) fmt
+  let groupinstall ver fmt =
+    match ver with
+    | 3 ->
+        (* dnf3 syntax which was deprecated but worked in dnf4 *)
+        ksprintf
+          (fun s -> run "yum groupinstall -y %s && yum clean packages" s)
+          fmt
+    | _ ->
+        (* dnf4 and dnf5 syntax *)
+        ksprintf
+          (fun s -> run "yum group install -y %s && yum clean packages" s)
+          fmt
 
   let dev_packages ?extra () =
     install

--- a/src-opam/linux.mli
+++ b/src-opam/linux.mli
@@ -36,8 +36,9 @@ module RPM : sig
   val install : ('a, unit, string, t) format4 -> 'a
   (** [install fmt] will run [yum install] on the supplied package list. *)
 
-  val groupinstall : ('a, unit, string, t) format4 -> 'a
-  (** [groupinstall fmt] will run [yum groupinstall] on the supplied package list. *)
+  val groupinstall : int -> ('a, unit, string, t) format4 -> 'a
+  (** [groupinstall ver fmt] will run [yum groupinstall] or [yum group install]
+      on the supplied package list. ver selects the appropriate syntax *)
 
   val add_user : ?uid:int -> ?gid:int -> ?sudo:bool -> string -> t
   (** [add_user username] will install a new user with name [username] and a locked


### PR DESCRIPTION
Updates the syntax of `dnf` to support DNF 5 used in Fedora 41.

DNF5 complete drops `groupinstall` where previously it has just been deprecated.