### PR TITLE
Match case between FROM and AS

### DIFF
--- a/src/dockerfile.ml
+++ b/src/dockerfile.ml
@@ -378,7 +378,7 @@ let rec string_of_line ~escape (t : line) =
              | Some p -> "--platform=" ^ p ^ " ");
              image;
              (match tag with None -> "" | Some t -> ":" ^ t);
-             (match alias with None -> "" | Some a -> " as " ^ a);
+             (match alias with None -> "" | Some a -> " AS " ^ a);
            ])
   | `Maintainer m -> cmd "MAINTAINER" m
   | `Run (mounts, network, security, c) ->


### PR DESCRIPTION
To avoid warnings of the form
```
#1 WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match
```
generate `FROM ... AS ...` clauses instead of `FROM ... as ...`