### PR TITLE
Use DNF 5 syntax for Fedora V41 and future versions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+
+- Use DNF 5 syntax for Fedora V41 and future versions (@mtelvers, #231)
+
 v8.2.6 2025-04-15
 -----------------
 

--- a/src-opam/opam.ml
+++ b/src-opam/opam.ml
@@ -561,13 +561,17 @@ let gen_opam2_distro ?override_tag ?(clone_opam_repo = true) ?arch ?labels
           | `CentOS _ -> true
           | _ -> false
         in
-        let c_devtools_libs : (t, unit, string, t) format4 =
+        let (dnf_version, c_devtools_libs) : int * (t, unit, string, t) format4
+            =
           match d with
-          | `Fedora `V41 -> {|"c-development"|}
-          | `Fedora _ -> {|"C Development Tools and Libraries"|}
-          | _ -> {|"Development Tools"|}
+          | `Fedora
+              ( `V21 | `V22 | `V23 | `V24 | `V25 | `V26 | `V27 | `V28 | `V29
+              | `V30 | `V31 | `V32 | `V33 | `V34 | `V35 | `V36 | `V37 | `V38
+              | `V39 | `V40 ) ->
+              (3, {|"C Development Tools and Libraries"|})
+          | `Fedora _ -> (5, {|"c-development"|})
+          | _ -> (3, {|"Development Tools"|})
         in
-        let dnf_version = match d with `Fedora `V41 -> 5 | _ -> 3 in
         yum_opam2 ?labels ?arch ~yum_workaround ~enable_powertools ~dnf_version
           ~c_devtools_libs ~opam_hashes d ()
     | `Zypper -> zypper_opam2 ?labels ?arch ~opam_hashes d ()


### PR DESCRIPTION
Fedora 41 and later use DNF version 5, which has a different syntax to the older DNF version 3. Previously, the code defaulted to using DNF v3 syntax and selected DNF v5 syntax only for Fedora 41. This has now been inverted. All old Fedora versions are specifically listed, and any unmatched version will now pick up DNF v5.