### PR TITLE
Deprecate Ubuntu 20.04

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,9 @@
 
+Unreleased
+----------
+
+- Deprecate Ubuntu 20.04, EOL 31 May 2025. (@mtelvers, #232)
+
 v8.2.7 2025-05-30
 -----------------
 

--- a/src-opam/distro.ml
+++ b/src-opam/distro.ml
@@ -418,11 +418,11 @@ let distro_status (d : t) : status =
         `Deprecated
     | `OpenSUSE `V15_6 -> `Active `Tier2
     | `OpenSUSE `Tumbleweed -> `Active `Tier2
-    | `Ubuntu (`V20_04 | `V22_04 | `V24_04 | `V24_10) -> `Active `Tier2
+    | `Ubuntu (`V22_04 | `V24_04 | `V24_10) -> `Active `Tier2
     | `Ubuntu
         ( `V12_04 | `V14_04 | `V15_04 | `V15_10 | `V16_04 | `V16_10 | `V17_04
-        | `V17_10 | `V18_04 | `V18_10 | `V19_04 | `V19_10 | `V20_10 | `V21_04
-        | `V21_10 | `V22_10 | `V23_04 | `V23_10 ) ->
+        | `V17_10 | `V18_04 | `V18_10 | `V19_04 | `V19_10 | `V20_04 | `V20_10
+        | `V21_04 | `V21_10 | `V22_10 | `V23_04 | `V23_10 ) ->
         `Deprecated
     | `Cygwin (`Ltsc2016 | `Ltsc2019) -> `Deprecated
     | `Cygwin `Ltsc2022 -> `Active `Tier3


### PR DESCRIPTION
Deprecate Ubuntu 20.04, EOL 31 May 2025.