### PR TITLE
Dockerfile.mount_cache: readonly is a flag, not a boolean

### DIFF
--- a/src/dockerfile.ml
+++ b/src/dockerfile.ml
@@ -308,7 +308,7 @@ let string_of_mount { typ } =
       String.concat ","
         ([ "--mount=type=cache" ] @ optional "id" id
         @ [ sprintf "target=%s" target ]
-        @ optional_bool "readonly" readonly
+        @ optional_flag "readonly" readonly
         @ (match sharing with
           | None -> []
           | Some `Shared -> [ "sharing=shared" ]


### PR DESCRIPTION
Attempting to set `readonly:true` results in this error: `readonly: must not provide an argument for option`

`readonly` is chosen by the presence of the flag, so use `optional_flag` instead.

Example working Dockerfile entry:
```
RUN --mount=type=cache,target=/home/opam/.opam/download-cache,readonly,sharing=shared,uid=1000,gid=1000 \
    --mount=type=cache,target=/home/opam/.cache/dune,sharing=shared,uid=1000,gid=1000 \
    opam-2.3 install --locked --with-test . --deps-only
```

generated from this code that uses ocaml-dockerfile:
```
let with_opam_download_cache ?(ro = false) ?(home = home) ?(uid = 1000)
    ?(gid = 1000) t =
  let target = Filename.concat home ".opam/download-cache" in
  let readonly, sharing =
    if ro then (Some true, `Shared) else (None, `Locked)
  in
  let mounts =
    [Dockerfile.mount_cache ?readonly ~target ~sharing ~uid ~gid ()]
  in
  with_mounts mounts t
```