### PR TITLE
Track Docker Layers

### DIFF
--- a/src/dockerfile.ml
+++ b/src/dockerfile.ml
@@ -577,7 +577,6 @@ let string_of_t tl =
   Buffer.contents buf
 
 let layers (t : t) : int =
-  let t = crunch t in
   let is_layer = function
     | `From _ | `Run _ | `Copy _ | `Add _ -> true
     | _ -> false

--- a/src/dockerfile.ml
+++ b/src/dockerfile.ml
@@ -576,4 +576,16 @@ let string_of_t tl =
   outside tl;
   Buffer.contents buf
 
+let layers (t : t) : int =
+  let t = crunch t in
+  let is_layer = function
+    | `From _
+    | `Run _
+    | `Copy _
+    | `Add _
+     -> true
+    | _ -> false
+  in
+  List.fold_left (fun acc l -> if is_layer l then acc + 1 else acc) 0 t
+
 let pp ppf tl = Fmt.pf ppf "%s" (string_of_t tl)

--- a/src/dockerfile.ml
+++ b/src/dockerfile.ml
@@ -579,11 +579,7 @@ let string_of_t tl =
 let layers (t : t) : int =
   let t = crunch t in
   let is_layer = function
-    | `From _
-    | `Run _
-    | `Copy _
-    | `Add _
-     -> true
+    | `From _ | `Run _ | `Copy _ | `Add _ -> true
     | _ -> false
   in
   List.fold_left (fun acc l -> if is_layer l then acc + 1 else acc) 0 t

--- a/src/dockerfile.mli
+++ b/src/dockerfile.mli
@@ -602,6 +602,8 @@ val crunch : t -> t
       if mounts or networks or security modes differ for each run command. *)
 
 val layers : t -> int
-(** [layers t] approximates the number of layers that would be produced by the Docker
-    build of this Dockerfile. Each {!from}, {!run}, {!copy}, {!add}
-    command produces a new layer. Note that multiple run commands can be combined into a single layer using {!crunch} and hence should be accounted for. *)
+(** [layers t] approximates the number of layers that would be produced by the
+    Docker build of this Dockerfile. Each {!from}, {!run}, {!copy}, {!add}
+    command produces a new layer. Note that multiple run commands can be
+    combined into a single layer using {!crunch} and hence should be accounted
+    for. *)

--- a/src/dockerfile.mli
+++ b/src/dockerfile.mli
@@ -600,3 +600,8 @@ val crunch : t -> t
 
     @raise Invalid_argument
       if mounts or networks or security modes differ for each run command. *)
+
+val layers : t -> int
+(** [layers t] approximates the number of layers that would be produced by the Docker
+    build of this Dockerfile. Each {!from}, {!run}, {!copy}, {!add}
+    command produces a new layer. Note that multiple run commands can be combined into a single layer using {!crunch} and hence should be accounted for. *)


### PR DESCRIPTION
This PR introduces a new layers function `val layers : t -> int` that approximates the number of filesystem layers a given Dockerfile (`Dockerfile.t`) will produce.
The function inspects each instruction in the Dockerfile (`Dockerfile.t`) and counts only those that are guaranteed to create a new image layer in Docker, see: https://docs.docker.com/engine/storage/drivers/#images-and-layers. These are `FROM`, `RUN`, `COPY`, and `ADD`.
Being able to estimate the layer count from `Dockerfile.t` will help inform decisions regarding image size and build performance as well as help analyze the cost of adding new instructions