### PR TITLE
Reset Count for Multi Layer Builds

### DIFF
--- a/src/dockerfile.ml
+++ b/src/dockerfile.ml
@@ -581,6 +581,9 @@ let layers (t : t) : int =
     | `From _ | `Run _ | `Copy _ | `Add _ -> true
     | _ -> false
   in
-  List.fold_left (fun acc l -> if is_layer l then acc + 1 else acc) 0 t
+  List.fold_left
+    (fun acc l ->
+      match l with `From _ -> 1 | _ -> if is_layer l then acc + 1 else acc)
+    0 t
 
 let pp ppf tl = Fmt.pf ppf "%s" (string_of_t tl)


### PR DESCRIPTION
follow up to: https://github.com/ocurrent/ocaml-dockerfile/pull/239#issuecomment-3338618507

This PR updates the layers function to correctly handle multi-stage Dockerfiles. The layer count now resets to 1 at each `FROM` instruction, reflecting the start of a new build stage. 